### PR TITLE
feat: add networkChanged() — proactive recovery on network switch (WiFi/VPN/cellular)

### DIFF
--- a/docs/research/expandation/02-network-env.md
+++ b/docs/research/expandation/02-network-env.md
@@ -137,7 +137,7 @@ catcher 当前已支持 HTTP 代理和 SOCKS5 代理。但生产环境中代理�
 
 | 场景 | catcher 覆盖 | 建议 |
 |------|:----------:|------|
-| VPN 连接建立/断开 | 网络接口状态变化 | ❌ | 是否检测到网络变化并重建连接池 |
+| VPN 连接建立/断开 | 网络接口状态变化 | ✅ `networkChanged()` | 宿主 App 主动通知：清 DNS 缓存 + 重建连接池 + WS 立即重连（见 user-manual/resilience.md 第七节） |
 | Split Tunnel | 部分流量走 VPN，部分直连 | ❌ | DNS 解析走不同解析器 |
 | VPN DNS 泄露 | DNS 不走 VPN 隧道 | ❌ | 需文档说明 DNS 配置的隐私影响 |
 | MTU 变化 | VPN 降低有效 MTU (TLS overhead) | ❌ | 大 payload 可能被 fragment |
@@ -183,7 +183,7 @@ catcher 的 E2E 测试已覆盖 7 种预设网络条件（good→metro），以�
 5. **代理返回非预期 Content-Type** — 不 panic，错误信息清晰
 6. **网络闪断时 CB 误触发** — CB 阈值需考虑网络闪断模式
 7. **Gray failure** — 部分成功/部分失败时 retry 策略
-8. **VPN 网络变化检测** — 连接池是否感知网络接口变化
+8. **VPN 网络变化检测** — ✅ 已实现 `networkChanged()` API：宿主 App 感知网络变化后主动通知，立即重建连接池/重连 WS/清 DNS 缓存（全平台绑定均已暴露）
 
 ### 中优先级
 

--- a/docs/user-manual/resilience.md
+++ b/docs/user-manual/resilience.md
@@ -685,6 +685,7 @@ const client = createHttpClient({
 | 高频交易 | 1 | fixed 100ms | 3s | 10 / 5s | 20 |
 | 移动弱网 | 5 | exponential | 60s | 8 / 15s | 3 |
 | 批处理 | 10 | exponential | 300s | 20 / 60s | 2 |
+| 微服务内网 | 3 | exponential | 5s | 3 / 5s | 50 |
 
 ---
 
@@ -782,4 +783,11 @@ catcher_ws_network_changed(ws_handle);      // FfiResult
   避免每次通断都触发重连风暴。
 - **不调用也能恢复**：`networkChanged()` 是优化而非必需 — 不调用时
   心跳超时/keepalive 探针仍会兜底自愈，只是慢 10-30 秒。
-| 微服务内网 | 3 | exponential | 5s | 3 / 5s | 50 |
+- **DNS 服务器不会重读**：解析器的 nameserver 列表在创建时确定
+  （系统配置仅读取一次）。`networkChanged()` 清空解析缓存，但若新网络
+  推送了不同的系统 DNS 服务器，需要自定义 `dns.nameservers` 或重建客户端。
+- **建议配合 reconnect 配置**：WS 未配置 `reconnect` 时 `networkChanged()`
+  只做一次立即重连；切换瞬间网络常有 1-3 秒不可用窗口，一次尝试可能失败
+  并以 `Error` 事件终止。配置了 `reconnect` 则失败后自动落入退避重试。
+- **连接建立前调用会报错**：客户端还在初始连接过程中时调用
+  `networkChanged()` 会返回"未连接"错误，宿主回调中建议忽略该错误。

--- a/docs/user-manual/resilience.md
+++ b/docs/user-manual/resilience.md
@@ -786,6 +786,9 @@ catcher_ws_network_changed(ws_handle);      // FfiResult
 - **DNS 服务器不会重读**：解析器的 nameserver 列表在创建时确定
   （系统配置仅读取一次）。`networkChanged()` 清空解析缓存，但若新网络
   推送了不同的系统 DNS 服务器，需要自定义 `dns.nameservers` 或重建客户端。
+- **发送超时**（WS）：半开连接上的发送会阻塞到 TCP 重传超时（分钟级）。
+  `send_timeout_ms`（默认 10s，0 = 不限制）保证单帧发送超时后立即判定
+  断线进入重连，事件循环不会被卡住。
 - **建议配合 reconnect 配置**：WS 未配置 `reconnect` 时 `networkChanged()`
   只做一次立即重连；切换瞬间网络常有 1-3 秒不可用窗口，一次尝试可能失败
   并以 `Error` 事件终止。配置了 `reconnect` 则失败后自动落入退避重试。

--- a/docs/user-manual/resilience.md
+++ b/docs/user-manual/resilience.md
@@ -13,6 +13,7 @@
 - [四、优先级队列（Priority Queue）](#四优先级队列priority-queue)
 - [五、自适应行为](#五自适应行为)
 - [六、参数调优推荐](#六参数调优推荐)
+- [七、网络变化通知](#七网络变化通知network-change-notification)
 
 ---
 
@@ -684,4 +685,101 @@ const client = createHttpClient({
 | 高频交易 | 1 | fixed 100ms | 3s | 10 / 5s | 20 |
 | 移动弱网 | 5 | exponential | 60s | 8 / 15s | 3 |
 | 批处理 | 10 | exponential | 300s | 20 / 60s | 2 |
+
+---
+
+## 七、网络变化通知（Network Change Notification）
+
+### 7.1 问题：网络切换后的"半开连接"
+
+WiFi 切换热点、WiFi ↔ 蜂窝切换、VPN 连接/断开/换节点时，旧网络上建立的
+TCP 连接不会收到 RST/FIN，而是静默变成**半开连接**（half-open）。被动检测
+需要等待：
+
+| 协议 | 被动检测手段 | 检测延迟 |
+|------|------------|---------|
+| WebSocket | 心跳 pong 超时 / 连续丢 pong | 10-30 秒 |
+| HTTP | TCP keepalive 探针 / 请求失败 | 最长 20 秒+ |
+| DNS | 缓存 TTL 过期后后台刷新 | 最长 300 秒 |
+
+对 IM、实时推送等场景，这个延迟不可接受。
+
+### 7.2 方案：宿主 App 主动通知
+
+宿主应用通常能从操作系统**立即**感知网络变化（iOS `NWPathMonitor`、
+Android `ConnectivityManager`、Flutter `connectivity_plus`、浏览器
+`navigator.onLine`）。`networkChanged()` 把这个信号传给 catcher：
+
+**WebSocket 客户端**（`WsHandle::network_changed()` / `ws.networkChanged()`）：
+
+1. 立即丢弃当前（半开的）连接 — 不发 Close 帧，不等心跳超时
+2. 清空 DNS 缓存
+3. 重置重连退避计数（旧网络的失败不带入新网络）
+4. 跳过退避延迟立即重连；正在退避等待中的也会被打断
+5. 多端点配置时重新竞速 — 新网络下最优端点可能不同
+
+**HTTP 客户端**（`HttpTransport::network_changed()` / `client.networkChanged()`）：
+
+1. 清空 DNS 缓存
+2. 重建连接池 — 丢弃所有可能半开的 keep-alive 连接
+3. 重置熔断器 — 切换期间的失败不应让新网络背锅
+4. 飞行中的请求不受影响（其重试会自动建立新连接）
+
+### 7.3 各平台用法
+
+```typescript
+// Node.js / Electron (@eric8810/catcher-napi-http / catcher-napi-ws)
+import { HttpClient } from '@eric8810/catcher-napi-http'
+import { WsClient } from '@eric8810/catcher-napi-ws'
+
+// Electron 主进程可监听系统网络事件，或由渲染进程转发 navigator.onLine
+onNetworkChange(() => {
+  httpClient.networkChanged()
+  wsClient.networkChanged()
+})
+```
+
+```dart
+// Flutter (catcher_core) — 配合 connectivity_plus
+Connectivity().onConnectivityChanged.listen((_) {
+  httpClient.networkChanged();
+  wsClient.networkChanged();
+});
+```
+
+```swift
+// iOS (catcher-uniffi) — 配合 NWPathMonitor
+monitor.pathUpdateHandler = { _ in
+    try? httpClient.networkChanged()
+    try? wsClient.networkChanged()
+}
+```
+
+```kotlin
+// Android (catcher-uniffi) — 配合 ConnectivityManager
+override fun onAvailable(network: Network) {
+    httpClient.networkChanged()
+    wsClient.networkChanged()
+}
+```
+
+```rust
+// Rust (catcher-http / catcher-ws)
+transport.network_changed()?;   // HTTP
+ws_handle.network_changed()?;   // WebSocket
+```
+
+```c
+// C ABI (catcher-ffi)
+catcher_http_network_changed(http_handle);  // 0=成功
+catcher_ws_network_changed(ws_handle);      // FfiResult
+```
+
+### 7.4 注意事项
+
+- **幂等**：连续多次调用安全，每次都执行完整的清理+重建。
+- **防抖建议**：网络闪断（flapping）场景下建议宿主侧做 1-2 秒防抖，
+  避免每次通断都触发重连风暴。
+- **不调用也能恢复**：`networkChanged()` 是优化而非必需 — 不调用时
+  心跳超时/keepalive 探针仍会兜底自愈，只是慢 10-30 秒。
 | 微服务内网 | 3 | exponential | 5s | 3 / 5s | 50 |

--- a/packages/catcher-dns/src/lib.rs
+++ b/packages/catcher-dns/src/lib.rs
@@ -185,6 +185,7 @@ fn with_port(addrs: Vec<SocketAddr>, port: u16) -> Vec<SocketAddr> {
 mod hickory_backend {
     use std::collections::HashSet;
     use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
@@ -213,6 +214,9 @@ mod hickory_backend {
         stale_ttl: Duration,
         stale_on_error: bool,
         refreshing: Arc<Mutex<HashSet<String>>>,
+        /// 缓存代际 — clear_cache() 时递增。在旧代际发起的解析结果
+        /// 不允许写入新代际的缓存（防止网络切换后旧网络的解析结果回灌）。
+        generation: Arc<AtomicU64>,
     }
 
     impl HickoryDnsResolver {
@@ -233,6 +237,7 @@ mod hickory_backend {
                 stale_ttl: Duration::from_secs(config.stale_ttl_secs as u64),
                 stale_on_error: config.stale_on_error,
                 refreshing: Arc::new(Mutex::new(HashSet::new())),
+                generation: Arc::new(AtomicU64::new(0)),
             })
         }
 
@@ -242,9 +247,15 @@ mod hickory_backend {
         }
 
         /// 立即失效全部缓存条目（含 hickory 内部缓存）。
+        ///
+        /// 递增代际计数：清空时刻之前发起、之后才完成的解析（后台 stale
+        /// 刷新或并发查询）属于旧网络，其结果不会留在新代际的缓存中。
         pub(super) fn clear_cache(&self) {
+            self.generation.fetch_add(1, Ordering::SeqCst);
             self.cache.invalidate_all();
             self.resolver.clear_cache();
+            // 放行被旧代际刷新任务占位的 hostname，允许立即发起新解析
+            self.refreshing.lock().clear();
         }
 
         async fn do_resolve(
@@ -284,19 +295,24 @@ mod hickory_backend {
                 if age < self.cache_ttl + self.stale_ttl {
                     let refresh = self.clone();
                     let key = hostname.to_string();
+                    let gen_at_start = self.generation.load(Ordering::SeqCst);
                     if self.refreshing.lock().insert(key.clone()) {
                         tokio::spawn(async move {
                             if let Ok(addrs) = refresh.do_resolve(&key).await {
-                                refresh
-                                    .cache
-                                    .insert(
-                                        key.clone(),
-                                        DnsCacheEntry {
-                                            addrs,
-                                            inserted: Instant::now(),
-                                        },
-                                    )
-                                    .await;
+                                // 解析期间发生 clear_cache（网络已切换）：
+                                // 结果来自旧网络，丢弃
+                                if refresh.generation.load(Ordering::SeqCst) == gen_at_start {
+                                    refresh
+                                        .cache
+                                        .insert(
+                                            key.clone(),
+                                            DnsCacheEntry {
+                                                addrs,
+                                                inserted: Instant::now(),
+                                            },
+                                        )
+                                        .await;
+                                }
                             }
                             refresh.refreshing.lock().remove(&key);
                         });
@@ -307,6 +323,7 @@ mod hickory_backend {
 
             let resolver = self.clone();
             let key = hostname.to_string();
+            let gen_at_start = self.generation.load(Ordering::SeqCst);
             let result = self
                 .cache
                 .try_get_with::<_, String>(hostname.to_string(), async move {
@@ -319,6 +336,13 @@ mod hickory_backend {
                     }
                 })
                 .await;
+
+            // 解析期间发生 clear_cache（网络已切换）：本次结果可能来自旧网络。
+            // 仍返回给当前调用方（连接失败会自行重试），但从缓存中移除，
+            // 下一次解析强制走新网络的全新查询。
+            if self.generation.load(Ordering::SeqCst) != gen_at_start {
+                self.cache.invalidate(hostname).await;
+            }
 
             match result {
                 Ok(entry) => Ok(entry.addrs.clone()),

--- a/packages/catcher-dns/src/lib.rs
+++ b/packages/catcher-dns/src/lib.rs
@@ -140,6 +140,21 @@ impl DnsResolver {
         }
     }
 
+    /// 网络环境变化时的完整恢复：清空缓存 + 重建底层解析器。
+    ///
+    /// 仅 `clear_cache()` 不够：底层解析器的 nameserver 列表在创建时确定
+    /// （系统配置只读一次），UDP socket 也绑定在旧网络接口上。新网络往往
+    /// 推送不同的 DNS 服务器（VPN/蜂窝切换尤其明显），重建解析器会重读
+    /// 系统 DNS 配置并重新建立到 nameserver 的连接。
+    /// 关闭 `hickory-dns` feature 时每次解析都走系统调用，为 no-op。
+    pub fn network_changed(&self) -> Result<(), CatcherError> {
+        #[cfg(feature = "hickory-dns")]
+        {
+            self.inner.network_changed()?;
+        }
+        Ok(())
+    }
+
     #[cfg(test)]
     fn has_host_mapping(&self, hostname: &str) -> bool {
         #[cfg(feature = "hickory-dns")]
@@ -195,7 +210,7 @@ mod hickory_backend {
     use hickory_resolver::name_server::TokioConnectionProvider;
     use hickory_resolver::TokioResolver;
     use moka::future::Cache;
-    use parking_lot::Mutex;
+    use parking_lot::{Mutex, RwLock};
 
     use crate::{parse_host_mapping, with_port, DnsConfig};
 
@@ -207,7 +222,11 @@ mod hickory_backend {
 
     #[derive(Clone, Debug)]
     pub(super) struct HickoryDnsResolver {
-        resolver: TokioResolver,
+        /// 底层解析器 — RwLock 包装以支持 network_changed() 热重建
+        /// （重读系统 DNS 配置、重建绑定在新网络接口上的 socket）
+        resolver: Arc<RwLock<TokioResolver>>,
+        /// 重建解析器所需的配置
+        config: DnsConfig,
         cache: Cache<String, DnsCacheEntry>,
         host_mapping: std::collections::HashMap<String, Vec<SocketAddr>>,
         cache_ttl: Duration,
@@ -230,7 +249,8 @@ mod hickory_backend {
                 .build();
 
             Ok(Self {
-                resolver,
+                resolver: Arc::new(RwLock::new(resolver)),
+                config: config.clone(),
                 cache,
                 host_mapping: parse_host_mapping(&config.host_mapping)?,
                 cache_ttl: Duration::from_secs(config.cache_ttl_secs as u64),
@@ -253,17 +273,30 @@ mod hickory_backend {
         pub(super) fn clear_cache(&self) {
             self.generation.fetch_add(1, Ordering::SeqCst);
             self.cache.invalidate_all();
-            self.resolver.clear_cache();
+            self.resolver.read().clear_cache();
             // 放行被旧代际刷新任务占位的 hostname，允许立即发起新解析
             self.refreshing.lock().clear();
+        }
+
+        /// 网络变化恢复：清空缓存 + 重建底层解析器。
+        ///
+        /// 重建会重读系统 DNS 配置（未显式配置 nameservers 时）并重新
+        /// 建立到 nameserver 的 socket — 旧 socket 可能仍绑定在已失效
+        /// 的网络接口上。重建失败时保留旧解析器（缓存已清空），返回错误。
+        pub(super) fn network_changed(&self) -> Result<(), CatcherError> {
+            self.clear_cache();
+            let new_resolver = build_inner_resolver(&self.config)?;
+            *self.resolver.write() = new_resolver;
+            Ok(())
         }
 
         async fn do_resolve(
             &self,
             hostname: &str,
         ) -> Result<Vec<SocketAddr>, Box<dyn std::error::Error + Send + Sync>> {
-            let lookup = self
-                .resolver
+            // 克隆出当前解析器（内部 Arc，克隆廉价），不跨 await 持锁
+            let resolver = self.resolver.read().clone();
+            let lookup = resolver
                 .lookup_ip(hostname)
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
@@ -575,6 +608,28 @@ mod tests {
         assert_eq!(addrs, vec!["127.0.0.1:8080".parse().expect("valid addr")]);
         // 再次清空应幂等
         resolver.clear_cache();
+    }
+
+    #[tokio::test]
+    async fn network_changed_rebuilds_resolver_and_keeps_resolving() {
+        let config = DnsConfig {
+            host_mapping: vec![("api.test".to_string(), "127.0.0.1".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let resolver = build_stale_aware_resolver(&config).expect("valid resolver");
+        resolver
+            .network_changed()
+            .expect("rebuild with same config succeeds");
+        // 重建后仍可解析（host_mapping 与新解析器都可用）
+        let addrs = resolver
+            .resolve_socket_addrs("api.test", 9090)
+            .await
+            .expect("resolves after rebuild");
+        assert_eq!(addrs, vec!["127.0.0.1:9090".parse().expect("valid addr")]);
+        // 幂等
+        resolver.network_changed().expect("idempotent");
     }
 
     #[tokio::test]

--- a/packages/catcher-dns/src/lib.rs
+++ b/packages/catcher-dns/src/lib.rs
@@ -128,6 +128,18 @@ impl DnsResolver {
         }
     }
 
+    /// 清空 DNS 缓存。
+    ///
+    /// 网络环境变化（WiFi 切换、VPN 换节点等）后旧解析结果可能指向不可达
+    /// 地址，调用此方法立即失效缓存，下次解析走全新查询。`host_mapping`
+    /// 是静态配置，不受影响。关闭 `hickory-dns` feature 时无缓存，为 no-op。
+    pub fn clear_cache(&self) {
+        #[cfg(feature = "hickory-dns")]
+        {
+            self.inner.clear_cache();
+        }
+    }
+
     #[cfg(test)]
     fn has_host_mapping(&self, hostname: &str) -> bool {
         #[cfg(feature = "hickory-dns")]
@@ -227,6 +239,12 @@ mod hickory_backend {
         #[cfg(test)]
         pub(super) fn has_host_mapping(&self, hostname: &str) -> bool {
             self.host_mapping.contains_key(hostname)
+        }
+
+        /// 立即失效全部缓存条目（含 hickory 内部缓存）。
+        pub(super) fn clear_cache(&self) {
+            self.cache.invalidate_all();
+            self.resolver.clear_cache();
         }
 
         async fn do_resolve(
@@ -514,6 +532,25 @@ mod tests {
             msg.contains("not-an-ip"),
             "error should mention the bad IP: {msg}"
         );
+    }
+
+    #[tokio::test]
+    async fn clear_cache_keeps_host_mapping_resolvable() {
+        let config = DnsConfig {
+            host_mapping: vec![("api.test".to_string(), "127.0.0.1".to_string())]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        let resolver = build_stale_aware_resolver(&config).expect("valid resolver");
+        resolver.clear_cache();
+        let addrs = resolver
+            .resolve_socket_addrs("api.test", 8080)
+            .await
+            .expect("host mapping survives clear_cache");
+        assert_eq!(addrs, vec!["127.0.0.1:8080".parse().expect("valid addr")]);
+        // 再次清空应幂等
+        resolver.clear_cache();
     }
 
     #[tokio::test]

--- a/packages/catcher-ffi/tests/http_test.rs
+++ b/packages/catcher-ffi/tests/http_test.rs
@@ -59,6 +59,39 @@ async fn h01_create_and_destroy_client() {
     unsafe { http::catcher_http_client_destroy(handle); }
 }
 
+/// destroy 之后用旧句柄调用任何 API 必须安全失败（句柄是注册表 id
+/// 而非堆指针，不存在 use-after-free）。网络监听回调线程在 App 销毁
+/// 客户端后仍可能触发，这是真实会发生的时序。
+#[tokio::test]
+async fn h16_stale_handle_after_destroy_is_safe() {
+    let config = r#"{"base_url":"https://httpbin.org","connect_timeout_ms":5000}"#;
+    let c_config = CString::new(config).unwrap();
+
+    let handle = unsafe { http::catcher_http_client_create(c_config.as_ptr()) };
+    assert!(!handle.is_null());
+    unsafe { http::catcher_http_client_destroy(handle); }
+
+    // 全部 API 用已销毁的句柄调用：不崩溃、返回失败码
+    unsafe {
+        assert_eq!(http::catcher_http_network_changed(handle), 1);
+        assert_eq!(http::catcher_http_cancel_request(handle, 1), -1);
+        http::catcher_http_client_cancel_all(handle); // 应为 no-op
+        // 重复 destroy 安全
+        http::catcher_http_client_destroy(handle);
+    }
+}
+
+/// 凭空伪造的句柄值也必须安全失败（不解引用调用方指针）
+#[tokio::test]
+async fn h17_garbage_handle_is_safe() {
+    let garbage = 0x7fff_ffff_usize as *mut std::ffi::c_void;
+    unsafe {
+        assert_eq!(http::catcher_http_network_changed(garbage), 1);
+        assert_eq!(http::catcher_http_cancel_request(garbage, 1), -1);
+        http::catcher_http_client_destroy(garbage);
+    }
+}
+
 #[tokio::test]
 async fn h02_get_request_with_wiremock() {
     use wiremock::{MockServer, Mock, ResponseTemplate};

--- a/packages/catcher-http/src/ffi/http_ffi.rs
+++ b/packages/catcher-http/src/ffi/http_ffi.rs
@@ -350,6 +350,22 @@ pub unsafe extern "C" fn catcher_http_metrics(handle: *mut c_void) -> *mut c_cha
     CString::new(json).unwrap_or_default().into_raw()
 }
 
+/// 通知 HTTP 客户端网络环境已变化（WiFi 切换 / VPN 换节点等）。
+/// 清空 DNS 缓存、重建连接池（丢弃半开连接）、重置熔断器。
+/// 返回 0 成功，1 句柄无效，2 重建失败。
+#[no_mangle]
+pub unsafe extern "C" fn catcher_http_network_changed(handle: *mut c_void) -> i32 {
+    if handle.is_null() { return 1; }
+    let id = *(handle as *const usize);
+    match REGISTRY.get(id) {
+        Some(transport) => match transport.network_changed() {
+            Ok(()) => 0,
+            Err(_) => 2,
+        },
+        None => 1,
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_client_cancel_all(handle: *mut c_void) {
     if handle.is_null() { return; }

--- a/packages/catcher-http/src/ffi/http_ffi.rs
+++ b/packages/catcher-http/src/ffi/http_ffi.rs
@@ -89,6 +89,9 @@ fn invoke_http_callback(
 
 // ── Lifecycle ──
 
+/// 创建 HTTP 客户端。返回的句柄是注册表 id 直接编码为指针值（id ≥ 1，
+/// 与 null 不冲突），**不指向任何内存** — destroy 之后用旧句柄调用任何
+/// API 都安全失败，而不是 use-after-free。
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_client_create(config_json: *const c_char) -> *mut c_void {
     if config_json.is_null() { return std::ptr::null_mut(); }
@@ -102,15 +105,14 @@ pub unsafe extern "C" fn catcher_http_client_create(config_json: *const c_char) 
         Err(_) => return std::ptr::null_mut(),
     };
     let id = REGISTRY.insert(Arc::new(transport));
-    Box::into_raw(Box::new(id)) as *mut c_void
+    id as *mut c_void
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_client_destroy(handle: *mut c_void) {
     if handle.is_null() { return; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     REGISTRY.remove(id);
-    drop(Box::from_raw(handle as *mut usize));
 }
 
 // ── Original FFI (unchanged signatures — backward compatible) ──
@@ -122,7 +124,7 @@ pub unsafe extern "C" fn catcher_http_get(
     callback: EventCallback, user_data: *mut c_void,
 ) {
     if handle.is_null() { return; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let url_str = ffi_string_to_string(url, "/");
     let per_request_headers = parse_headers_json(headers_json);
     let per_request_timeout = if timeout_ms > 0 { Some(timeout_ms as u64) } else { None };
@@ -152,7 +154,7 @@ pub unsafe extern "C" fn catcher_http_post(
     callback: EventCallback, user_data: *mut c_void,
 ) {
     if handle.is_null() { return; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let url_str = ffi_string_to_string(url, "/");
     let body_data = read_body_bytes(body, body_len);
     let ct_str = ffi_string_to_string(content_type, "application/octet-stream");
@@ -185,7 +187,7 @@ pub unsafe extern "C" fn catcher_http_execute(
     callback: EventCallback, user_data: *mut c_void,
 ) {
     if handle.is_null() { return; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let method_str = ffi_string_to_string(method, "GET");
     let url_str = ffi_string_to_string(url, "/");
     let body_data = if !body.is_null() && body_len > 0 {
@@ -240,7 +242,7 @@ pub unsafe extern "C" fn catcher_http_execute_with_id(
     callback: EventCallback, user_data: *mut c_void,
 ) -> u64 {
     if handle.is_null() { return 0; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let method_str = ffi_string_to_string(method, "GET");
     let url_str = ffi_string_to_string(url, "/");
     let body_data = if !body.is_null() && body_len > 0 {
@@ -318,7 +320,7 @@ pub unsafe extern "C" fn catcher_http_cancel_request(
     handle: *mut c_void, request_id: u64,
 ) -> i32 {
     if handle.is_null() { return -1; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     if let Some(transport) = REGISTRY.get(id) {
         if transport.cancel_request(request_id) { 0 } else { -1 }
     } else { -1 }
@@ -329,7 +331,7 @@ pub unsafe extern "C" fn catcher_http_cancel_request(
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_circuit_breaker_state(handle: *mut c_void) -> *mut c_char {
     if handle.is_null() { return std::ptr::null_mut(); }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let state = REGISTRY.get(id).and_then(|t| t.circuit_breaker_state());
     let json = match state {
         Some(s) => serde_json::to_string(&s).unwrap_or_default(),
@@ -341,7 +343,7 @@ pub unsafe extern "C" fn catcher_http_circuit_breaker_state(handle: *mut c_void)
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_metrics(handle: *mut c_void) -> *mut c_char {
     if handle.is_null() { return std::ptr::null_mut(); }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let snapshot = REGISTRY.get(id).map(|t| t.metrics());
     let json = match snapshot {
         Some(s) => serde_json::to_string(&s).unwrap_or_default(),
@@ -356,7 +358,7 @@ pub unsafe extern "C" fn catcher_http_metrics(handle: *mut c_void) -> *mut c_cha
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_network_changed(handle: *mut c_void) -> i32 {
     if handle.is_null() { return 1; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     match REGISTRY.get(id) {
         Some(transport) => match transport.network_changed() {
             Ok(()) => 0,
@@ -369,7 +371,7 @@ pub unsafe extern "C" fn catcher_http_network_changed(handle: *mut c_void) -> i3
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_client_cancel_all(handle: *mut c_void) {
     if handle.is_null() { return; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     if let Some(transport) = REGISTRY.get(id) {
         transport.cancel_all();
     }
@@ -382,7 +384,7 @@ pub unsafe extern "C" fn catcher_http_adaptive_timeout_config(
     multiplier_scaled: u32, window_size: u32,
 ) {
     if handle.is_null() { return; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     if let Some(transport) = REGISTRY.get(id) {
         if enabled != 0 {
             transport.set_adaptive_timeout(
@@ -406,7 +408,7 @@ pub unsafe extern "C" fn catcher_http_execute_stream(
     callback: EventCallback, user_data: *mut c_void,
 ) -> u64 {
     if handle.is_null() { return 0; }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let method_str = ffi_string_to_string(method, "GET");
     let url_str = ffi_string_to_string(url, "/");
     let body_data = if !body.is_null() && body_len > 0 {
@@ -503,7 +505,7 @@ pub unsafe extern "C" fn catcher_http_multipart(
         Some(cb) => cb,
         None => return,
     };
-    let id_val = *(handle as *const usize);
+    let id_val = handle as usize;
 
     let method_str = if method.is_null() {
         HttpMethod::POST

--- a/packages/catcher-http/src/ffi/quality_ffi.rs
+++ b/packages/catcher-http/src/ffi/quality_ffi.rs
@@ -147,7 +147,15 @@ pub unsafe extern "C" fn catcher_quality_subscribe(
 #[no_mangle]
 pub unsafe extern "C" fn catcher_quality_unsubscribe(sub_handle: *mut c_void) {
     if sub_handle.is_null() { return; }
+    // 先从订阅表移除，仅当句柄确实在表中时才回收 —
+    // 重复 unsubscribe 或传入无效句柄都安全返回，避免 double-free/UAF
+    {
+        let mut subs = SUBSCRIPTIONS.lock().unwrap();
+        let Some(pos) = subs.iter().position(|&p| p == sub_handle as usize) else {
+            return;
+        };
+        subs.remove(pos);
+    }
     let sub: Box<crate::observability::network_quality::QualitySubscription> = Box::from_raw(sub_handle as *mut _);
     sub.unsubscribe();
-    SUBSCRIPTIONS.lock().unwrap().retain(|&p| p != sub_handle as usize);
 }

--- a/packages/catcher-http/src/ffi/sse_ffi.rs
+++ b/packages/catcher-http/src/ffi/sse_ffi.rs
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn catcher_sse_connect(
                     }
                 });
 
-                Box::into_raw(Box::new(id)) as usize
+                id
             }
             Err(_) => 0usize,
             }
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn catcher_sse_ready_state(sse_handle: *mut c_void) -> i32
     if sse_handle.is_null() {
         return -1;
     }
-    let id = *(sse_handle as *const usize);
+    let id = sse_handle as usize;
     SSE_REGISTRY.get(id)
         .map(|client| match client.blocking_lock().ready_state() {
             SseReadyState::Connecting => 0,
@@ -261,7 +261,7 @@ pub unsafe extern "C" fn catcher_sse_last_event_id(sse_handle: *mut c_void) -> *
     if sse_handle.is_null() {
         return std::ptr::null_mut();
     }
-    let id = *(sse_handle as *const usize);
+    let id = sse_handle as usize;
     SSE_REGISTRY.get(id)
         .map(|client| {
             let last_id = client.blocking_lock().last_event_id();
@@ -276,7 +276,7 @@ pub unsafe extern "C" fn catcher_sse_close(sse_handle: *mut c_void) {
     if sse_handle.is_null() {
         return;
     }
-    let id = *(sse_handle as *const usize);
+    let id = sse_handle as usize;
     if let Some(client) = SSE_REGISTRY.get(id) {
         client.blocking_lock().close();
     }
@@ -288,7 +288,6 @@ pub unsafe extern "C" fn catcher_sse_destroy(sse_handle: *mut c_void) {
     if sse_handle.is_null() {
         return;
     }
-    let id = *(sse_handle as *const usize);
+    let id = sse_handle as usize;
     SSE_REGISTRY.remove(id);
-    drop(Box::from_raw(sse_handle as *mut usize));
 }

--- a/packages/catcher-http/src/transport/dns.rs
+++ b/packages/catcher-http/src/transport/dns.rs
@@ -15,6 +15,13 @@ mod reqwest_resolver {
         inner: Arc<DnsResolver>,
     }
 
+    impl ReqwestDnsResolver {
+        /// 清空 DNS 缓存（网络环境变化后调用）。
+        pub(crate) fn clear_cache(&self) {
+            self.inner.clear_cache();
+        }
+    }
+
     impl reqwest::dns::Resolve for ReqwestDnsResolver {
         fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
             let inner = self.inner.clone();
@@ -39,7 +46,7 @@ mod reqwest_resolver {
 }
 
 #[cfg(feature = "hickory-dns")]
-pub(crate) use reqwest_resolver::build_stale_aware_resolver;
+pub(crate) use reqwest_resolver::{build_stale_aware_resolver, ReqwestDnsResolver};
 
 #[cfg(test)]
 mod tests {

--- a/packages/catcher-http/src/transport/dns.rs
+++ b/packages/catcher-http/src/transport/dns.rs
@@ -16,9 +16,10 @@ mod reqwest_resolver {
     }
 
     impl ReqwestDnsResolver {
-        /// 清空 DNS 缓存（网络环境变化后调用）。
-        pub(crate) fn clear_cache(&self) {
-            self.inner.clear_cache();
+        /// 网络环境变化恢复：清空缓存 + 重建底层解析器（重读系统 DNS 配置）。
+        /// 重建失败时旧解析器保持可用（缓存已清空），调用方可继续。
+        pub(crate) fn network_changed(&self) -> Result<(), CatcherError> {
+            self.inner.network_changed()
         }
     }
 

--- a/packages/catcher-http/src/transport/http_client.rs
+++ b/packages/catcher-http/src/transport/http_client.rs
@@ -36,6 +36,9 @@ pub struct HttpTransport {
     cancel_token: Arc<Mutex<tokio_util::sync::CancellationToken>>,
     metrics: MetricsCollector,
     adaptive_timeout: Mutex<Option<AdaptiveTimeout>>,
+    /// 网络代际 — network_changed() 时递增。旧代际发起的请求失败时
+    /// 不计入熔断器（那是旧网络的失败，不应惩罚新网络）。
+    network_generation: AtomicU64,
     /// Per-request cancel tokens, keyed by request_id (N-03)
     pending_requests: Mutex<HashMap<u64, tokio_util::sync::CancellationToken>>,
     next_request_id: AtomicU64,
@@ -103,6 +106,7 @@ impl HttpTransport {
             cancel_token: Arc::new(Mutex::new(tokio_util::sync::CancellationToken::new())),
             metrics,
             adaptive_timeout: Mutex::new(None),
+            network_generation: AtomicU64::new(0),
             pending_requests: Mutex::new(HashMap::new()),
             next_request_id: AtomicU64::new(1),
             concurrency_semaphore,
@@ -110,11 +114,13 @@ impl HttpTransport {
         })
     }
 
-    /// 当前底层客户端的克隆（ClientWithMiddleware 内部是 Arc，克隆开销小）
+    /// 当前底层客户端的克隆（ClientWithMiddleware 内部是 Arc，克隆开销小）。
+    /// 锁中毒时直接取内部值：client 的写入是整体赋值，不存在半更新状态，
+    /// 且 panic 不能穿过 C ABI（会导致宿主进程 abort）。
     fn client(&self) -> ClientWithMiddleware {
         self.client
             .read()
-            .expect("client lock poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .clone()
     }
 
@@ -132,17 +138,21 @@ impl HttpTransport {
         #[cfg(feature = "hickory-dns")]
         self.dns_resolver.clear_cache();
 
+        // 熔断器先重置：即使客户端重建失败（如 TLS 证书文件被移除），
+        // 旧网络造成的熔断状态也不应继续拒绝新网络上的请求。
+        // 代际递增使旧网络上仍在飞行的请求失败时不再计入熔断。
+        self.network_generation.fetch_add(1, Ordering::SeqCst);
+        if let Some(ref cb) = self.circuit_breaker {
+            cb.reset();
+        }
+
         let new_client = build_middleware_client(
             &self.config,
             &self.metrics,
             #[cfg(feature = "hickory-dns")]
             &self.dns_resolver,
         )?;
-        *self.client.write().expect("client lock poisoned") = new_client;
-
-        if let Some(ref cb) = self.circuit_breaker {
-            cb.reset();
-        }
+        *self.client.write().unwrap_or_else(|e| e.into_inner()) = new_client;
         Ok(())
     }
 }
@@ -154,94 +164,92 @@ fn build_middleware_client(
     metrics: &MetricsCollector,
     #[cfg(feature = "hickory-dns")] dns_resolver: &Arc<crate::transport::dns::ReqwestDnsResolver>,
 ) -> Result<ClientWithMiddleware, CatcherError> {
+    let mut reqwest_builder = Client::builder()
+        .connect_timeout(Duration::from_millis(config.connect_timeout_ms))
+        .pool_max_idle_per_host(config.pool.max_idle_per_host)
+        .pool_idle_timeout(Duration::from_secs(config.pool.idle_timeout_secs))
+        .tcp_keepalive(
+            config
+                .pool
+                .keep_alive
+                .then(|| Duration::from_secs(config.pool.keep_alive_interval_secs)),
+        )
+        .tcp_keepalive_interval(
+            config
+                .pool
+                .keep_alive
+                .then(|| Duration::from_secs(config.pool.keep_alive_interval_secs)),
+        )
+        .tcp_keepalive_retries(config.pool.keep_alive.then_some(3));
+
+    // G8: TLS configuration
+    reqwest_builder = build_tls_config(reqwest_builder, &config.tls)?;
+
+    // G7: DNS resolution — 复用共享解析器（缓存跨连接池重建保留，可显式清空）
+    #[cfg(feature = "hickory-dns")]
     {
-        let mut reqwest_builder = Client::builder()
-            .connect_timeout(Duration::from_millis(config.connect_timeout_ms))
-            .pool_max_idle_per_host(config.pool.max_idle_per_host)
-            .pool_idle_timeout(Duration::from_secs(config.pool.idle_timeout_secs))
-            .tcp_keepalive(
-                config
-                    .pool
-                    .keep_alive
-                    .then(|| Duration::from_secs(config.pool.keep_alive_interval_secs)),
-            )
-            .tcp_keepalive_interval(
-                config
-                    .pool
-                    .keep_alive
-                    .then(|| Duration::from_secs(config.pool.keep_alive_interval_secs)),
-            )
-            .tcp_keepalive_retries(config.pool.keep_alive.then_some(3));
-
-        // G8: TLS configuration
-        reqwest_builder = build_tls_config(reqwest_builder, &config.tls)?;
-
-        // G7: DNS resolution — 复用共享解析器（缓存跨连接池重建保留，可显式清空）
-        #[cfg(feature = "hickory-dns")]
-        {
-            reqwest_builder = reqwest_builder.dns_resolver(dns_resolver.clone());
-        }
-
-        // G4: Proxy configuration
-        if let Some(ref proxy_config) = config.proxy {
-            let mut proxy = reqwest::Proxy::all(&proxy_config.url)
-                .map_err(|e| CatcherError::InvalidConfig(format!("invalid proxy URL: {e}")))?;
-            if let Some(ref auth) = proxy_config.auth {
-                proxy = proxy.basic_auth(&auth.username, &auth.password);
-            }
-            // G4: noProxy — exclude matching hostnames from proxying
-            if !proxy_config.no_proxy.is_empty() {
-                let no_proxy_str = proxy_config.no_proxy.join(",");
-                let no_proxy = reqwest::NoProxy::from_string(&no_proxy_str);
-                proxy = proxy.no_proxy(no_proxy);
-            }
-            reqwest_builder = reqwest_builder.proxy(proxy);
-        }
-
-        // G6: Redirect policy
-        reqwest_builder = match &config.redirect {
-            Some(r) if !r.follow => reqwest_builder.redirect(reqwest::redirect::Policy::none()),
-            Some(r) => reqwest_builder.redirect(reqwest::redirect::Policy::limited(r.max_redirects as usize)),
-            None => reqwest_builder,
-        };
-
-        // G12: Auth — set default headers for basic auth and bearer token
-        if let Some(ref auth) = config.auth {
-            let encoded = base64_encode(&format!("{}:{}", auth.username, auth.password));
-            let mut headers = reqwest::header::HeaderMap::new();
-            headers.insert(
-                "Authorization",
-                format!("Basic {}", encoded).parse()
-                    .map_err(|e| CatcherError::InvalidConfig(format!("invalid basic auth header: {e}")))?,
-            );
-            reqwest_builder = reqwest_builder.default_headers(headers);
-        }
-        if let Some(ref token) = config.bearer_token {
-            let mut headers = reqwest::header::HeaderMap::new();
-            headers.insert(
-                "Authorization",
-                format!("Bearer {}", token).parse()
-                    .map_err(|e| CatcherError::InvalidConfig(format!("invalid bearer token header: {e}")))?,
-            );
-            reqwest_builder = reqwest_builder.default_headers(headers);
-        }
-
-        let reqwest_client = reqwest_builder
-            .build()
-            .map_err(|e| CatcherError::Internal(format!("reqwest build error: {e}")))?;
-
-        // Phase 3: Wrap with middleware (retry)
-        let mut client_builder = MiddlewareBuilder::new(reqwest_client);
-        if let Some(ref retry) = config.retry {
-            let policy = build_retry_policy(retry);
-            client_builder = client_builder.with(MetricsRetryMiddleware::new(
-                policy,
-                metrics.http_retries_weak(),
-            ));
-        }
-
-        Ok(client_builder.build())
+        reqwest_builder = reqwest_builder.dns_resolver(dns_resolver.clone());
     }
+
+    // G4: Proxy configuration
+    if let Some(ref proxy_config) = config.proxy {
+        let mut proxy = reqwest::Proxy::all(&proxy_config.url)
+            .map_err(|e| CatcherError::InvalidConfig(format!("invalid proxy URL: {e}")))?;
+        if let Some(ref auth) = proxy_config.auth {
+            proxy = proxy.basic_auth(&auth.username, &auth.password);
+        }
+        // G4: noProxy — exclude matching hostnames from proxying
+        if !proxy_config.no_proxy.is_empty() {
+            let no_proxy_str = proxy_config.no_proxy.join(",");
+            let no_proxy = reqwest::NoProxy::from_string(&no_proxy_str);
+            proxy = proxy.no_proxy(no_proxy);
+        }
+        reqwest_builder = reqwest_builder.proxy(proxy);
+    }
+
+    // G6: Redirect policy
+    reqwest_builder = match &config.redirect {
+        Some(r) if !r.follow => reqwest_builder.redirect(reqwest::redirect::Policy::none()),
+        Some(r) => reqwest_builder.redirect(reqwest::redirect::Policy::limited(r.max_redirects as usize)),
+        None => reqwest_builder,
+    };
+
+    // G12: Auth — set default headers for basic auth and bearer token
+    if let Some(ref auth) = config.auth {
+        let encoded = base64_encode(&format!("{}:{}", auth.username, auth.password));
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            format!("Basic {}", encoded).parse()
+                .map_err(|e| CatcherError::InvalidConfig(format!("invalid basic auth header: {e}")))?,
+        );
+        reqwest_builder = reqwest_builder.default_headers(headers);
+    }
+    if let Some(ref token) = config.bearer_token {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "Authorization",
+            format!("Bearer {}", token).parse()
+                .map_err(|e| CatcherError::InvalidConfig(format!("invalid bearer token header: {e}")))?,
+        );
+        reqwest_builder = reqwest_builder.default_headers(headers);
+    }
+
+    let reqwest_client = reqwest_builder
+        .build()
+        .map_err(|e| CatcherError::Internal(format!("reqwest build error: {e}")))?;
+
+    // Phase 3: Wrap with middleware (retry)
+    let mut client_builder = MiddlewareBuilder::new(reqwest_client);
+    if let Some(ref retry) = config.retry {
+        let policy = build_retry_policy(retry);
+        client_builder = client_builder.with(MetricsRetryMiddleware::new(
+            policy,
+            metrics.http_retries_weak(),
+        ));
+    }
+
+    Ok(client_builder.build())
 }
 
 impl HttpTransport {
@@ -265,6 +273,7 @@ impl HttpTransport {
         mut request: HttpRequest,
     ) -> (u64, Result<HttpResponse, CatcherError>) {
         let start = Instant::now();
+        let gen_at_start = self.network_generation.load(Ordering::SeqCst);
 
         if let Some(ref cb) = self.circuit_breaker {
             if let Err(e) = cb.before_request() {
@@ -381,7 +390,10 @@ impl HttpTransport {
             Err(_) => {
                 self.metrics.record_http_request(false, elapsed_us);
                 if let Some(ref cb) = self.circuit_breaker {
-                    cb.on_failure();
+                    // 请求发起后网络已切换：失败属于旧网络，不计入新网络的熔断
+                    if self.network_generation.load(Ordering::SeqCst) == gen_at_start {
+                        cb.on_failure();
+                    }
                 }
             }
         }

--- a/packages/catcher-http/src/transport/http_client.rs
+++ b/packages/catcher-http/src/transport/http_client.rs
@@ -1,7 +1,7 @@
 use reqwest::Client;
 use reqwest_middleware::{ClientBuilder as MiddlewareBuilder, ClientWithMiddleware};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
@@ -25,8 +25,13 @@ use catcher_core::types::resilience::CbState;
 /// Phase 6: 增加 per-request cancel (N-03)
 /// Phase 7: 增加 Semaphore 并发控制 + 优先级队列 (A-01)
 pub struct HttpTransport {
-    client: ClientWithMiddleware,
+    /// 底层客户端 — RwLock 包装以支持 network_changed() 热替换
+    /// （重建连接池，丢弃网络切换后残留的半开 keep-alive 连接）
+    client: RwLock<ClientWithMiddleware>,
     config: Arc<HttpClientConfig>,
+    /// 共享 DNS 解析器 — network_changed() 时清空缓存
+    #[cfg(feature = "hickory-dns")]
+    dns_resolver: Arc<crate::transport::dns::ReqwestDnsResolver>,
     circuit_breaker: Option<CircuitBreaker>,
     cancel_token: Arc<Mutex<tokio_util::sync::CancellationToken>>,
     metrics: MetricsCollector,
@@ -43,6 +48,113 @@ pub struct HttpTransport {
 impl HttpTransport {
     /// 根据 HttpClientConfig 构建 HttpTransport
     pub fn new(config: HttpClientConfig) -> Result<Self, CatcherError> {
+        // G7: DNS resolution — always build shared DNS resolver for caching
+        #[cfg(feature = "hickory-dns")]
+        let dns_resolver = {
+            let dns_config = config.dns.clone().unwrap_or_default();
+            crate::transport::dns::build_stale_aware_resolver(&dns_config)?
+        };
+
+        let metrics = MetricsCollector::new();
+        let client = build_middleware_client(
+            &config,
+            &metrics,
+            #[cfg(feature = "hickory-dns")]
+            &dns_resolver,
+        )?;
+
+        let circuit_breaker = config
+            .circuit_breaker
+            .as_ref()
+            .map(|cb| CircuitBreaker::new(cb.clone()));
+
+        // A-01: Priority-based request queue with concurrency control.
+        // PriorityRequestQueue starts Tokio worker tasks during construction, so only
+        // enable it when HttpTransport::new() is called inside an active runtime.
+        // Synchronous constructors (notably napi) fall back to semaphore-only
+        // concurrency control and still execute requests on their async methods.
+        let (concurrency_semaphore, priority_queue) = if config.max_concurrency > 0 {
+            if Handle::try_current().is_ok() {
+                let queue_config = catcher_core::types::scheduler::QueueConfig {
+                    max_concurrency: config.max_concurrency as usize,
+                    queue_capacity: 1024,
+                    default_timeout_ms: config.response_timeout_ms,
+                    concurrency_mode: catcher_core::types::scheduler::ConcurrencyMode::Fixed(
+                        config.max_concurrency as usize,
+                    ),
+                };
+                (
+                    None, // priority_queue handles concurrency internally
+                    Some(crate::scheduler::PriorityRequestQueue::new(queue_config)),
+                )
+            } else {
+                (Some(Arc::new(Semaphore::new(config.max_concurrency as usize))), None)
+            }
+        } else {
+            (None, None)
+        };
+
+        Ok(Self {
+            client: RwLock::new(client),
+            config: Arc::new(config),
+            #[cfg(feature = "hickory-dns")]
+            dns_resolver,
+            circuit_breaker,
+            cancel_token: Arc::new(Mutex::new(tokio_util::sync::CancellationToken::new())),
+            metrics,
+            adaptive_timeout: Mutex::new(None),
+            pending_requests: Mutex::new(HashMap::new()),
+            next_request_id: AtomicU64::new(1),
+            concurrency_semaphore,
+            priority_queue,
+        })
+    }
+
+    /// 当前底层客户端的克隆（ClientWithMiddleware 内部是 Arc，克隆开销小）
+    fn client(&self) -> ClientWithMiddleware {
+        self.client
+            .read()
+            .expect("client lock poisoned")
+            .clone()
+    }
+
+    /// 通知库网络环境已发生变化（WiFi 切换、VPN 换节点、蜂窝/WiFi 切换等）。
+    ///
+    /// 网络切换后旧连接池中的 keep-alive 连接全部变成半开连接，被动等待
+    /// TCP keepalive 探针（默认 20s）或请求失败才会清理。调用此方法立即：
+    ///
+    /// 1. 清空 DNS 缓存 — 新网络下解析结果可能不同（VPN 场景尤其明显）
+    /// 2. 重建底层客户端 — 丢弃整个旧连接池，后续请求走全新 TCP 连接
+    /// 3. 重置熔断器 — 切换期间的失败属于旧网络，不应惩罚新网络
+    ///
+    /// 飞行中的请求不受影响：其内部重试会自动建立新连接。
+    pub fn network_changed(&self) -> Result<(), CatcherError> {
+        #[cfg(feature = "hickory-dns")]
+        self.dns_resolver.clear_cache();
+
+        let new_client = build_middleware_client(
+            &self.config,
+            &self.metrics,
+            #[cfg(feature = "hickory-dns")]
+            &self.dns_resolver,
+        )?;
+        *self.client.write().expect("client lock poisoned") = new_client;
+
+        if let Some(ref cb) = self.circuit_breaker {
+            cb.reset();
+        }
+        Ok(())
+    }
+}
+
+/// 构建底层 reqwest + middleware 客户端。
+/// 独立函数以便 network_changed() 热重建连接池时复用。
+fn build_middleware_client(
+    config: &HttpClientConfig,
+    metrics: &MetricsCollector,
+    #[cfg(feature = "hickory-dns")] dns_resolver: &Arc<crate::transport::dns::ReqwestDnsResolver>,
+) -> Result<ClientWithMiddleware, CatcherError> {
+    {
         let mut reqwest_builder = Client::builder()
             .connect_timeout(Duration::from_millis(config.connect_timeout_ms))
             .pool_max_idle_per_host(config.pool.max_idle_per_host)
@@ -64,12 +176,10 @@ impl HttpTransport {
         // G8: TLS configuration
         reqwest_builder = build_tls_config(reqwest_builder, &config.tls)?;
 
-        // G7: DNS resolution — always build shared DNS resolver for caching
+        // G7: DNS resolution — 复用共享解析器（缓存跨连接池重建保留，可显式清空）
         #[cfg(feature = "hickory-dns")]
         {
-            let dns_config = config.dns.clone().unwrap_or_default();
-            let resolver = crate::transport::dns::build_stale_aware_resolver(&dns_config)?;
-            reqwest_builder = reqwest_builder.dns_resolver(resolver);
+            reqwest_builder = reqwest_builder.dns_resolver(dns_resolver.clone());
         }
 
         // G4: Proxy configuration
@@ -121,7 +231,6 @@ impl HttpTransport {
             .map_err(|e| CatcherError::Internal(format!("reqwest build error: {e}")))?;
 
         // Phase 3: Wrap with middleware (retry)
-        let metrics = MetricsCollector::new();
         let mut client_builder = MiddlewareBuilder::new(reqwest_client);
         if let Some(ref retry) = config.retry {
             let policy = build_retry_policy(retry);
@@ -131,51 +240,11 @@ impl HttpTransport {
             ));
         }
 
-        let circuit_breaker = config
-            .circuit_breaker
-            .as_ref()
-            .map(|cb| CircuitBreaker::new(cb.clone()));
-
-        // A-01: Priority-based request queue with concurrency control.
-        // PriorityRequestQueue starts Tokio worker tasks during construction, so only
-        // enable it when HttpTransport::new() is called inside an active runtime.
-        // Synchronous constructors (notably napi) fall back to semaphore-only
-        // concurrency control and still execute requests on their async methods.
-        let (concurrency_semaphore, priority_queue) = if config.max_concurrency > 0 {
-            if Handle::try_current().is_ok() {
-                let queue_config = catcher_core::types::scheduler::QueueConfig {
-                    max_concurrency: config.max_concurrency as usize,
-                    queue_capacity: 1024,
-                    default_timeout_ms: config.response_timeout_ms,
-                    concurrency_mode: catcher_core::types::scheduler::ConcurrencyMode::Fixed(
-                        config.max_concurrency as usize,
-                    ),
-                };
-                (
-                    None, // priority_queue handles concurrency internally
-                    Some(crate::scheduler::PriorityRequestQueue::new(queue_config)),
-                )
-            } else {
-                (Some(Arc::new(Semaphore::new(config.max_concurrency as usize))), None)
-            }
-        } else {
-            (None, None)
-        };
-
-        Ok(Self {
-            client: client_builder.build(),
-            config: Arc::new(config),
-            circuit_breaker,
-            cancel_token: Arc::new(Mutex::new(tokio_util::sync::CancellationToken::new())),
-            metrics,
-            adaptive_timeout: Mutex::new(None),
-            pending_requests: Mutex::new(HashMap::new()),
-            next_request_id: AtomicU64::new(1),
-            concurrency_semaphore,
-            priority_queue,
-        })
+        Ok(client_builder.build())
     }
+}
 
+impl HttpTransport {
     /// 发起 HTTP 请求（带熔断器检查 + cancel 支持 + metrics 记录 + 自适应超时 + 并发控制）
     pub async fn execute(&self, request: HttpRequest) -> Result<HttpResponse, CatcherError> {
         let (_, result) = self.execute_with_token(
@@ -220,7 +289,7 @@ impl HttpTransport {
         // A-01: Acquire concurrency slot — priority queue or semaphore
         let result = if let Some(ref queue) = self.priority_queue {
             // Priority queue path: handles both concurrency and priority ordering
-            let client = self.client.clone();
+            let client = self.client();
             let config = self.config.clone();
             let priority = request.priority;
             let timeout_ms = request.timeout_ms;
@@ -372,7 +441,7 @@ impl HttpTransport {
 
     /// 使用预分配的 token 执行请求（N-03，供 FFI 层使用）。
     async fn do_execute(&self, request: HttpRequest) -> Result<HttpResponse, CatcherError> {
-        execute_http_request(self.client.clone(), self.config.clone(), request).await
+        execute_http_request(self.client(), self.config.clone(), request).await
     }
 
     /// 流式执行 HTTP 请求（N-02），逐 chunk 通过回调推送。
@@ -400,7 +469,8 @@ impl HttpTransport {
             format!("{}{}", self.config.base_url.trim_end_matches('/'), request.url)
         };
 
-        let mut req = self.client.request(method, &url);
+        let client = self.client();
+        let mut req = client.request(method, &url);
         for (k, v) in &self.config.default_headers { req = req.header(k, v); }
         for (k, v) in &request.headers { req = req.header(k, v); }
         // B-02: multipart support
@@ -850,6 +920,61 @@ mod tests {
         assert_eq!(base64_encode("ab"), "YWI=");
         assert_eq!(base64_encode("abc"), "YWJj");
         assert_eq!(base64_encode("test"), "dGVzdA==");
+    }
+
+    // ── 网络变化通知 tests ──
+
+    /// network_changed() 重建客户端后，新请求应正常工作
+    #[tokio::test]
+    async fn network_changed_rebuilds_client_and_requests_work() {
+        use wiremock::{MockServer, Mock, ResponseTemplate};
+        use wiremock::matchers::method;
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let config = HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        };
+        let transport = HttpTransport::new(config).unwrap();
+
+        assert!(transport.get("/test").await.is_ok());
+        transport.network_changed().unwrap();
+        assert!(transport.get("/test").await.is_ok());
+        // 幂等：连续调用不应出错
+        transport.network_changed().unwrap();
+        transport.network_changed().unwrap();
+        assert!(transport.get("/test").await.is_ok());
+    }
+
+    /// network_changed() 应重置熔断器 — 切换期间的失败不惩罚新网络
+    #[tokio::test]
+    async fn network_changed_resets_circuit_breaker() {
+        use catcher_core::types::resilience::CircuitBreakerConfig;
+
+        let config = HttpClientConfig {
+            base_url: "http://127.0.0.1:1".to_string(), // 不可达 → 制造失败
+            connect_timeout_ms: 200,
+            response_timeout_ms: 200,
+            circuit_breaker: Some(CircuitBreakerConfig {
+                failure_threshold: 2,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let transport = HttpTransport::new(config).unwrap();
+
+        // 触发足够的失败让熔断器打开
+        let _ = transport.get("/test").await;
+        let _ = transport.get("/test").await;
+        assert_eq!(transport.circuit_breaker_state(), Some(CbState::Open));
+
+        transport.network_changed().unwrap();
+        assert_eq!(transport.circuit_breaker_state(), Some(CbState::Closed));
     }
 
     // ── N-02: Stream download tests ──

--- a/packages/catcher-http/src/transport/http_client.rs
+++ b/packages/catcher-http/src/transport/http_client.rs
@@ -135,8 +135,10 @@ impl HttpTransport {
     ///
     /// 飞行中的请求不受影响：其内部重试会自动建立新连接。
     pub fn network_changed(&self) -> Result<(), CatcherError> {
+        // 清缓存 + 重建解析器（重读系统 DNS 配置、重连 nameserver）。
+        // 重建失败时旧解析器仍可用且缓存已清空，继续重建连接池
         #[cfg(feature = "hickory-dns")]
-        self.dns_resolver.clear_cache();
+        let _ = self.dns_resolver.network_changed();
 
         // 熔断器先重置：即使客户端重建失败（如 TLS 证书文件被移除），
         // 旧网络造成的熔断状态也不应继续拒绝新网络上的请求。

--- a/packages/catcher-napi-http/src/client.rs
+++ b/packages/catcher-napi-http/src/client.rs
@@ -198,6 +198,22 @@ impl JsHttpClient {
         self.inner.disable_adaptive_timeout();
     }
 
+    // ── Network change ──
+
+    /// Notify the client that the network environment changed
+    /// (WiFi switch, VPN node change, cellular handover, ...).
+    ///
+    /// Clears the DNS cache, rebuilds the connection pool (dropping all
+    /// possibly half-open keep-alive sockets) and resets the circuit breaker,
+    /// so new requests immediately use fresh connections on the new network.
+    /// In-flight requests are unaffected.
+    #[napi]
+    pub fn network_changed(&self) -> napi::Result<()> {
+        self.inner
+            .network_changed()
+            .map_err(|e| napi::Error::from_reason(e.to_string()))
+    }
+
     // ── Cancel ──
 
     /// Cancel all in-flight requests.

--- a/packages/catcher-napi-http/ts/client.ts
+++ b/packages/catcher-napi-http/ts/client.ts
@@ -89,6 +89,19 @@ export class HttpClient {
     this._raw.disableAdaptiveTimeout()
   }
 
+  /**
+   * 通知客户端网络环境已变化（WiFi 切换 / VPN 换节点 / 蜂窝切换等）。
+   *
+   * 清空 DNS 缓存、重建连接池（丢弃可能半开的 keep-alive 连接）、重置
+   * 熔断器 — 新请求立即走新网络上的全新连接。飞行中的请求不受影响。
+   */
+  networkChanged(): void {
+    if (!this._raw.networkChanged) {
+      throw new Error('networkChanged() requires rebuilt native addon (cargo build)')
+    }
+    this._raw.networkChanged()
+  }
+
   cancelAll(): void {
     this._raw.cancelAll()
   }

--- a/packages/catcher-napi-ws/src/lib.rs
+++ b/packages/catcher-napi-ws/src/lib.rs
@@ -122,6 +122,23 @@ impl JsWsClient {
         }
     }
 
+    /// Notify the client that the network environment changed
+    /// (WiFi switch, VPN node change, cellular handover, ...).
+    ///
+    /// Immediately drops the (likely half-open) connection, clears the DNS
+    /// cache, resets reconnect backoff and reconnects right away — instead of
+    /// waiting 10-30s for heartbeat timeout. With multiple endpoints the race
+    /// is re-run, since the best endpoint may differ on the new network.
+    #[napi]
+    pub fn network_changed(&self) -> napi::Result<()> {
+        if let Some(ref h) = *self.handle.lock().unwrap() {
+            h.network_changed()
+                .map_err(|e| napi::Error::from_reason(e.to_string()))
+        } else {
+            Err(napi::Error::from_reason("WebSocket not connected"))
+        }
+    }
+
     /// Close the WebSocket connection with optional code and reason.
     ///
     /// Defaults to code 1000, reason "normal" if not specified.

--- a/packages/catcher-napi-ws/ts/client.ts
+++ b/packages/catcher-napi-ws/ts/client.ts
@@ -71,6 +71,9 @@ export class WsClient {
    * 马上重连 — 无需被动等待 10-30 秒心跳超时。多端点配置时重新竞速。
    */
   networkChanged(): void {
+    if (!this._raw.networkChanged) {
+      throw new Error('networkChanged() requires rebuilt native addon (cargo build)')
+    }
     this._raw.networkChanged()
   }
 

--- a/packages/catcher-napi-ws/ts/client.ts
+++ b/packages/catcher-napi-ws/ts/client.ts
@@ -64,6 +64,16 @@ export class WsClient {
     this._raw.sendBinary(buf)
   }
 
+  /**
+   * 通知客户端网络环境已变化（WiFi 切换 / VPN 换节点 / 蜂窝切换等）。
+   *
+   * 立即丢弃当前（大概率已半开的）连接、清空 DNS 缓存、重置重连退避并
+   * 马上重连 — 无需被动等待 10-30 秒心跳超时。多端点配置时重新竞速。
+   */
+  networkChanged(): void {
+    this._raw.networkChanged()
+  }
+
   /** 关闭连接。默认 code=1000, reason='normal' */
   close(code?: number, reason?: string): void {
     this._raw.close(code ?? null, reason ?? null)

--- a/packages/catcher-napi-ws/ts/types.ts
+++ b/packages/catcher-napi-ws/ts/types.ts
@@ -58,6 +58,8 @@ export interface WsClientConfig {
   deflate_threshold_bytes?: number
   /** 握手超时（ms）。默认: 15000 */
   handshake_timeout_ms?: number
+  /** 单帧发送超时（ms，0 = 不限制）。半开连接上的发送超时后判定断线并重连。默认: 10000 */
+  send_timeout_ms?: number
   /** 最大 payload（字节）。默认: 64MB */
   max_payload_bytes?: number
   /** 重连配置 */

--- a/packages/catcher-uniffi/src/lib.rs
+++ b/packages/catcher-uniffi/src/lib.rs
@@ -347,6 +347,19 @@ impl HttpClient {
             .map_err(|e| CatcherError::Network(e.to_string()))
     }
 
+    /// Notify the client that the network environment changed
+    /// (WiFi switch, VPN node change, cellular handover, ...).
+    ///
+    /// Call this from NWPathMonitor (iOS) / ConnectivityManager (Android)
+    /// callbacks. Clears the DNS cache, rebuilds the connection pool
+    /// (dropping half-open keep-alive sockets) and resets the circuit breaker.
+    #[uniffi::method]
+    pub fn network_changed(&self) -> Result<(), CatcherError> {
+        self.inner
+            .network_changed()
+            .map_err(|e| CatcherError::Network(e.to_string()))
+    }
+
     /// Query circuit breaker state as JSON string
     #[uniffi::method]
     pub fn circuit_breaker_state(&self) -> String {
@@ -463,6 +476,20 @@ impl WsClient {
     pub fn send_binary(&self, data: Vec<u8>) -> Result<(), CatcherError> {
         self.handle
             .send_binary(&data)
+            .map_err(|e| CatcherError::Network(e.to_string()))
+    }
+
+    /// Notify the client that the network environment changed
+    /// (WiFi switch, VPN node change, cellular handover, ...).
+    ///
+    /// Call this from NWPathMonitor (iOS) / ConnectivityManager (Android)
+    /// callbacks. Immediately drops the half-open connection, clears the DNS
+    /// cache, resets reconnect backoff and reconnects right away — instead of
+    /// waiting 10-30s for heartbeat timeout.
+    #[uniffi::method]
+    pub fn network_changed(&self) -> Result<(), CatcherError> {
+        self.handle
+            .network_changed()
             .map_err(|e| CatcherError::Network(e.to_string()))
     }
 

--- a/packages/catcher-ws/src/ffi/ws_ffi.rs
+++ b/packages/catcher-ws/src/ffi/ws_ffi.rs
@@ -145,6 +145,23 @@ pub unsafe extern "C" fn catcher_ws_close(handle: *mut c_void, code: u16, reason
     }
 }
 
+/// 通知 WS 客户端网络环境已变化（WiFi 切换 / VPN 换节点等）。
+/// 立即断开当前连接、清空 DNS 缓存、跳过退避延迟重连。
+#[no_mangle]
+pub unsafe extern "C" fn catcher_ws_network_changed(handle: *mut c_void) -> FfiResult {
+    if handle.is_null() {
+        return FfiResult::error(1, "null handle");
+    }
+    let id = *(handle as *const usize);
+    match WS_REGISTRY.get(id) {
+        Some(h) => match h.network_changed() {
+            Ok(()) => FfiResult::ok(std::ptr::null_mut(), 0),
+            Err(e) => FfiResult::error(1, &e.to_string()),
+        },
+        None => FfiResult::error(1, "handle not found"),
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn catcher_ws_destroy(handle: *mut c_void) {
     if handle.is_null() {

--- a/packages/catcher-ws/src/ffi/ws_ffi.rs
+++ b/packages/catcher-ws/src/ffi/ws_ffi.rs
@@ -46,6 +46,9 @@ fn invoke_event_callback(cb: EventCallback, event_name: &str, json: String, user
     );
 }
 
+/// 创建 WS 客户端。返回的句柄是注册表 id 直接编码为指针值（id ≥ 1，
+/// 与 null 不冲突），**不指向任何内存** — destroy 之后用旧句柄调用任何
+/// API 都安全返回 "handle not found"，而不是 use-after-free。
 #[no_mangle]
 pub unsafe extern "C" fn catcher_ws_create(
     config_json: *const c_char,
@@ -88,7 +91,7 @@ pub unsafe extern "C" fn catcher_ws_create(
         }
     });
 
-    Box::into_raw(Box::new(id)) as *mut c_void
+    id as *mut c_void
 }
 
 #[no_mangle]
@@ -99,7 +102,7 @@ pub unsafe extern "C" fn catcher_ws_send_text(
     if handle.is_null() {
         return FfiResult::error(1, "null handle");
     }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let text = ffi_string_to_string(message, "");
     match WS_REGISTRY.get(id) {
         Some(h) => match h.send_text(&text) {
@@ -122,7 +125,7 @@ pub unsafe extern "C" fn catcher_ws_send_binary(
     if data.is_null() {
         return FfiResult::error(1, "null data pointer");
     }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let bytes = std::slice::from_raw_parts(data, len);
     match WS_REGISTRY.get(id) {
         Some(h) => match h.send_binary(bytes) {
@@ -138,7 +141,7 @@ pub unsafe extern "C" fn catcher_ws_close(handle: *mut c_void, code: u16, reason
     if handle.is_null() {
         return;
     }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     let reason_str = ffi_string_to_string(reason, "normal");
     if let Some(h) = WS_REGISTRY.get(id) {
         let _ = h.close(code, &reason_str);
@@ -152,7 +155,7 @@ pub unsafe extern "C" fn catcher_ws_network_changed(handle: *mut c_void) -> FfiR
     if handle.is_null() {
         return FfiResult::error(1, "null handle");
     }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     match WS_REGISTRY.get(id) {
         Some(h) => match h.network_changed() {
             Ok(()) => FfiResult::ok(std::ptr::null_mut(), 0),
@@ -167,9 +170,8 @@ pub unsafe extern "C" fn catcher_ws_destroy(handle: *mut c_void) {
     if handle.is_null() {
         return;
     }
-    let id = *(handle as *const usize);
+    let id = handle as usize;
     WS_REGISTRY.remove(id);
-    drop(Box::from_raw(handle as *mut usize));
 }
 
 // Note: catcher_free_result is provided by catcher-core (ffi_types.rs).

--- a/packages/catcher-ws/src/transport/ws_client.rs
+++ b/packages/catcher-ws/src/transport/ws_client.rs
@@ -419,6 +419,29 @@ pub(crate) async fn connect_stream_with_resolver(
     Ok((stream, latency_ms))
 }
 
+/// 重连成功后重放缓存的发送命令（Close/NetworkChanged 已在缓存时被过滤）。
+async fn replay_buffered_commands(
+    stream: &mut WsStream,
+    commands: Vec<WsCommand>,
+    config: &WsClientConfig,
+) {
+    for cmd in commands {
+        match cmd {
+            WsCommand::Text(t) => {
+                if let Ok(msg) = encode_text_message(&t, config) {
+                    let _ = futures_util::SinkExt::send(stream, msg).await;
+                }
+            }
+            WsCommand::Binary(d) => {
+                if let Ok(msg) = encode_binary_message(&d, config) {
+                    let _ = futures_util::SinkExt::send(stream, msg).await;
+                }
+            }
+            WsCommand::Close { .. } | WsCommand::NetworkChanged => {}
+        }
+    }
+}
+
 /// 全量重连：多端点配置时重新竞速，单端点直接连接。
 /// 网络环境变化后调用 — 新网络下最优端点可能与之前不同。
 async fn connect_any_endpoint(
@@ -426,7 +449,10 @@ async fn connect_any_endpoint(
     resolver: &SharedDnsResolver,
 ) -> Result<(String, WsStream, u64), CatcherError> {
     if config.urls.len() > 1 || config.race_count > 1 {
-        let racer = EndpointRacer::new(config.urls.clone(), config.race_count);
+        // race_count 只限制初始连接的竞速宽度（EndpointRacer 内部 take(race_count)）。
+        // 网络变化后旧的最优端点可能已不可达，必须让每个端点都有机会。
+        let race_count = (config.urls.len() as u32).max(config.race_count);
+        let racer = EndpointRacer::new(config.urls.clone(), race_count);
         racer.race(config, resolver).await
     } else {
         let url = config
@@ -722,8 +748,34 @@ async fn connection_manager(
             }
         }
 
+        // 跨重连阶段缓存的待重放命令（Text/Binary）
+        let mut buffered_commands: Vec<WsCommand> = Vec::new();
+
         // ── 网络变化：清 DNS 缓存 + 跳过退避立即重连（即使未配置 reconnect）──
         if network_changed {
+            // 合并 OS 回调风暴：一次网络切换常触发多个连续回调（如 Android 的
+            // onAvailable / onCapabilitiesChanged），排空积压的 NetworkChanged
+            // 只重连一次；其余命令缓存等待重放，Close 中止
+            let mut close_requested = false;
+            loop {
+                match cmd_rx.try_recv() {
+                    Ok(WsCommand::NetworkChanged) => {}
+                    Ok(WsCommand::Close { .. }) => {
+                        close_requested = true;
+                        break;
+                    }
+                    Ok(cmd) => buffered_commands.push(cmd),
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        close_requested = true;
+                        break;
+                    }
+                }
+            }
+            if close_requested {
+                break;
+            }
+
             dns_resolver.clear_cache();
             if let Some(ref mut mgr) = reconnect_mgr {
                 mgr.reset();
@@ -732,26 +784,39 @@ async fn connection_manager(
                 attempt: 0,
                 delay_ms: 0,
             });
-            if let Ok((url, stream, lat)) = connect_any_endpoint(config, &dns_resolver).await {
-                current_url = url;
-                stream_opt = Some(stream);
-                first_latency = lat;
-                if let Some(ref mut mgr) = reconnect_mgr {
-                    mgr.on_connected();
+            match connect_any_endpoint(config, &dns_resolver).await {
+                Ok((url, mut stream, lat)) => {
+                    replay_buffered_commands(&mut stream, buffered_commands, config).await;
+                    current_url = url;
+                    stream_opt = Some(stream);
+                    first_latency = lat;
+                    if let Some(ref mut mgr) = reconnect_mgr {
+                        mgr.on_connected();
+                    }
+                    continue;
                 }
-                continue;
+                Err(e) => {
+                    // 无退避重连兜底时这是终态：补一个 Error 事件，
+                    // 避免消费者停留在 Reconnecting 状态等待一个不会来的结果
+                    if reconnect_mgr.is_none() {
+                        let _ = event_tx.send(WsEvent::Error {
+                            message: format!("network changed reconnect failed: {e}"),
+                        });
+                    }
+                    // 落入常规退避重连流程
+                }
             }
-            // 立即重连失败 — 落入常规退避重连流程
         }
 
         // ── 尝试重连 ──
         if let Some(ref mut mgr) = reconnect_mgr {
             let mut reconnected = false;
-            let mut buffered_commands: Vec<WsCommand> = Vec::new();
             let mut reconnect_latency_ms: u64 = 0;
 
-            // 网络变化触发的重连：重新竞速全部端点（而非固守 current_url）
-            let mut race_endpoints = false;
+            // 网络变化触发的重连：重新竞速全部端点（而非固守 current_url）。
+            // 立即重连失败落入本循环时必须继承这个意图，否则多端点配置下
+            // 会固守旧网络的获胜端点直到耗尽重试
+            let mut race_endpoints = network_changed;
 
             while let Some(delay) = mgr.on_disconnect() {
                 let attempt = mgr.attempt();
@@ -839,21 +904,7 @@ async fn connection_manager(
                 // 重连后回放缓存的命令（Close 已被过滤，不会到达这里）
                 if !buffered_commands.is_empty() {
                     if let Some(mut stream) = stream_opt.take() {
-                        for cmd in buffered_commands {
-                            match cmd {
-                                WsCommand::Text(t) => {
-                                    if let Ok(msg) = encode_text_message(&t, config) {
-                                        let _ = futures_util::SinkExt::send(&mut stream, msg).await;
-                                    }
-                                }
-                                WsCommand::Binary(d) => {
-                                    if let Ok(msg) = encode_binary_message(&d, config) {
-                                        let _ = futures_util::SinkExt::send(&mut stream, msg).await;
-                                    }
-                                }
-                                WsCommand::Close { .. } | WsCommand::NetworkChanged => {}
-                            }
-                        }
+                        replay_buffered_commands(&mut stream, buffered_commands, config).await;
                         stream_opt = Some(stream);
                     }
                 }
@@ -1174,6 +1225,158 @@ mod tests {
 
         let _ = handle.close(1000, "done");
         let _ = server.await;
+    }
+
+    /// network_changed() 应打断正在进行的退避等待并立即重连，
+    /// 且退避期间发送的消息在重连后被重放
+    #[tokio::test]
+    async fn network_changed_interrupts_backoff_and_replays_buffered() {
+        use tokio_tungstenite::tungstenite::Message;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // 第一段：接受一次连接后立刻断开 → 客户端进入 60s 退避
+        let first = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            drop(ws); // 直接断开
+        });
+
+        let config = WsClientConfig {
+            urls: vec![format!("ws://{addr}")],
+            handshake_timeout_ms: 1_000,
+            reconnect: Some(ReconnectConfig {
+                initial_delay_ms: 60_000, // 不打断的话测试必然超时
+                max_delay_ms: 60_000,
+                backoff_multiplier: 2.0,
+                max_attempts: 5,
+            }),
+            ..Default::default()
+        };
+
+        let (handle, mut rx) = WsTransport::connect(&config).await.unwrap();
+        first.await.unwrap();
+
+        // 等待进入退避（Connected → Disconnected → Reconnecting(1, 60000)）
+        loop {
+            let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if let WsEvent::Reconnecting { attempt, delay_ms } = ev {
+                assert_eq!(attempt, 1);
+                assert_eq!(delay_ms, 60_000);
+                break;
+            }
+        }
+
+        // 退避期间发送消息（应被缓存）并重新拉起服务器
+        handle.send_text("buffered during backoff").unwrap();
+        let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+        let second = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            // 读取重放的消息
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Text(t))) => return t.to_string(),
+                    Some(Ok(_)) => continue,
+                    other => panic!("expected replayed text, got {other:?}"),
+                }
+            }
+        });
+
+        handle.network_changed().unwrap();
+
+        // 2 秒内重连成功（60s 退避被打断）
+        loop {
+            let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+                .await
+                .expect("reconnect should not wait out the 60s backoff")
+                .unwrap();
+            if matches!(ev, WsEvent::Connected { .. }) {
+                break;
+            }
+        }
+
+        // 缓存的消息被重放到新连接
+        let replayed = tokio::time::timeout(Duration::from_secs(2), second)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(replayed, "buffered during backoff");
+
+        let _ = handle.close(1000, "done");
+    }
+
+    /// 多端点配置下 network_changed() 应重新竞速全部端点：
+    /// 原端点不可达时切换到其他端点（即使 race_count=1）
+    #[tokio::test]
+    async fn network_changed_re_races_all_endpoints() {
+        let listener_a = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr_a = listener_a.local_addr().unwrap();
+        let listener_b = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr_b = listener_b.local_addr().unwrap();
+
+        // A：接受初始连接后保持
+        let server_a = tokio::spawn(async move {
+            let (stream, _) = listener_a.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            tokio::spawn(async move {
+                let mut ws = ws;
+                while let Some(Ok(_)) = ws.next().await {}
+            });
+            listener_a // 持有 listener，稍后 drop 模拟端点不可达
+        });
+
+        // B：等待网络变化后的重连
+        let server_b = tokio::spawn(async move {
+            let (stream, _) = listener_b.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            tokio::spawn(async move {
+                let mut ws = ws;
+                while let Some(Ok(_)) = ws.next().await {}
+            });
+        });
+
+        let config = WsClientConfig {
+            urls: vec![format!("ws://{addr_a}"), format!("ws://{addr_b}")],
+            handshake_timeout_ms: 1_000,
+            race_count: 1, // 默认值：初始竞速只取第一个端点
+            ..Default::default()
+        };
+
+        let (handle, mut rx) = WsTransport::connect(&config).await.unwrap();
+        let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match first {
+            WsEvent::Connected { ref url, .. } => assert!(url.contains(&addr_a.to_string())),
+            other => panic!("expected Connected, got {other:?}"),
+        }
+
+        // A 端点下线，通知网络变化 → 重竞速应连上 B
+        let listener_a = server_a.await.unwrap();
+        drop(listener_a);
+        handle.network_changed().unwrap();
+
+        loop {
+            let ev = tokio::time::timeout(Duration::from_secs(3), rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if let WsEvent::Connected { url, .. } = ev {
+                assert!(
+                    url.contains(&addr_b.to_string()),
+                    "should fail over to endpoint B, got {url}"
+                );
+                break;
+            }
+        }
+
+        let _ = handle.close(1000, "done");
+        let _ = server_b.await;
     }
 
     /// 未配置 reconnect 时 network_changed() 也应执行一次立即重连

--- a/packages/catcher-ws/src/transport/ws_client.rs
+++ b/packages/catcher-ws/src/transport/ws_client.rs
@@ -419,6 +419,34 @@ pub(crate) async fn connect_stream_with_resolver(
     Ok((stream, latency_ms))
 }
 
+enum SendStatus {
+    Sent,
+    Failed,
+    TimedOut,
+}
+
+/// 带超时的帧发送。
+///
+/// 网络切换后连接变成半开时，发送会阻塞到 TCP 重传超时（分钟级），
+/// 期间事件循环无法处理任何命令（包括 network_changed / close）。
+/// 超时判定断线，让循环尽快进入重连流程。`timeout_ms == 0` 不限制。
+async fn send_frame_with_timeout<S>(writer: &mut S, frame: Frame, timeout_ms: u64) -> SendStatus
+where
+    S: futures_util::Sink<Frame> + Unpin,
+{
+    if timeout_ms == 0 {
+        return match writer.send(frame).await {
+            Ok(()) => SendStatus::Sent,
+            Err(_) => SendStatus::Failed,
+        };
+    }
+    match tokio::time::timeout(Duration::from_millis(timeout_ms), writer.send(frame)).await {
+        Ok(Ok(())) => SendStatus::Sent,
+        Ok(Err(_)) => SendStatus::Failed,
+        Err(_) => SendStatus::TimedOut,
+    }
+}
+
 /// 重连成功后重放缓存的发送命令（Close/NetworkChanged 已在缓存时被过滤）。
 async fn replay_buffered_commands(
     stream: &mut WsStream,
@@ -601,11 +629,16 @@ async fn connection_manager(
                                     continue;
                                 }
                             };
-                            if writer.send(msg).await.is_err() {
-                                break LoopOutcome::Disconnected {
+                            match send_frame_with_timeout(&mut writer, msg, config.send_timeout_ms).await {
+                                SendStatus::Sent => {}
+                                SendStatus::Failed => break LoopOutcome::Disconnected {
                                     code: 1006,
                                     reason: "send failed".into(),
-                                };
+                                },
+                                SendStatus::TimedOut => break LoopOutcome::Disconnected {
+                                    code: 1006,
+                                    reason: "send timeout".into(),
+                                },
                             }
                         }
                         Some(WsCommand::Binary(d)) => {
@@ -618,17 +651,30 @@ async fn connection_manager(
                                     continue;
                                 }
                             };
-                            if writer.send(msg).await.is_err() {
-                                break LoopOutcome::Disconnected {
+                            match send_frame_with_timeout(&mut writer, msg, config.send_timeout_ms).await {
+                                SendStatus::Sent => {}
+                                SendStatus::Failed => break LoopOutcome::Disconnected {
                                     code: 1006,
                                     reason: "send failed".into(),
-                                };
+                                },
+                                SendStatus::TimedOut => break LoopOutcome::Disconnected {
+                                    code: 1006,
+                                    reason: "send timeout".into(),
+                                },
                             }
                         }
                         Some(WsCommand::Close { code, reason }) => {
                             let msg = Frame::close(yawc::close::CloseCode::from(code), reason);
-                            let _ = writer.send(msg).await;
-                            let _ = writer.close().await;
+                            let _ = send_frame_with_timeout(&mut writer, msg, config.send_timeout_ms).await;
+                            if config.send_timeout_ms == 0 {
+                                let _ = writer.close().await;
+                            } else {
+                                let _ = tokio::time::timeout(
+                                    Duration::from_millis(config.send_timeout_ms),
+                                    writer.close(),
+                                )
+                                .await;
+                            }
                             break LoopOutcome::CleanClose;
                         }
                         Some(WsCommand::NetworkChanged) => {
@@ -655,7 +701,21 @@ async fn connection_manager(
                         }
                         state.waiting_for_pong = true;
                         state.ping_sent_at = Some(Instant::now());
-                        let _ = writer.send(Frame::ping(Vec::new())).await;
+                        if matches!(
+                            send_frame_with_timeout(
+                                &mut writer,
+                                Frame::ping(Vec::new()),
+                                config.send_timeout_ms,
+                            )
+                            .await,
+                            SendStatus::TimedOut
+                        ) {
+                            // 半开连接：ping 都发不出去，不必再等 pong 超时
+                            break LoopOutcome::Disconnected {
+                                code: 1006,
+                                reason: "ping send timeout".into(),
+                            };
+                        }
                         // 根据自适应间隔重设下一次 ping 时间
                         let next_ms = state.mgr.interval_ms();
                         ping_sleep.as_mut().reset(
@@ -706,12 +766,12 @@ async fn connection_manager(
                                     .unwrap_or("abnormal")
                                     .to_string();
                                 // RFC 6455 §5.5.1: 收到 Close 帧必须回一个 Close 帧
-                                let _ = writer
-                                    .send(Frame::close(
-                                        yawc::close::CloseCode::from(code),
-                                        &reason,
-                                    ))
-                                    .await;
+                                let _ = send_frame_with_timeout(
+                                    &mut writer,
+                                    Frame::close(yawc::close::CloseCode::from(code), &reason),
+                                    config.send_timeout_ms,
+                                )
+                                .await;
                                 break LoopOutcome::Disconnected { code, reason };
                             }
                             Some(_) => {}
@@ -776,7 +836,8 @@ async fn connection_manager(
                 break;
             }
 
-            dns_resolver.clear_cache();
+            // 清缓存 + 重建解析器（重读系统 DNS 配置）；重建失败时旧解析器仍可用
+            let _ = dns_resolver.network_changed();
             if let Some(ref mut mgr) = reconnect_mgr {
                 mgr.reset();
             }
@@ -872,7 +933,8 @@ async fn connection_manager(
                     break;
                 }
                 if skip_backoff {
-                    dns_resolver.clear_cache();
+                    // 清缓存 + 重建解析器（重读系统 DNS 配置）；重建失败时旧解析器仍可用
+            let _ = dns_resolver.network_changed();
                     mgr.reset();
                     race_endpoints = true;
                 }
@@ -1149,6 +1211,62 @@ mod tests {
         drop(result);
         bad_server.abort();
         let _ = good_server.await.unwrap();
+    }
+
+    /// 永远不就绪的 Sink — 模拟半开连接上发送阻塞
+    struct PendingSink;
+
+    impl futures_util::Sink<Frame> for PendingSink {
+        type Error = std::io::Error;
+
+        fn poll_ready(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Pending
+        }
+
+        fn start_send(self: std::pin::Pin<&mut Self>, _item: Frame) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Pending
+        }
+
+        fn poll_close(
+            self: std::pin::Pin<&mut Self>,
+            _cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            std::task::Poll::Pending
+        }
+    }
+
+    /// 半开连接上发送阻塞时应在 send_timeout_ms 内返回 TimedOut，
+    /// 而不是阻塞整个事件循环
+    #[tokio::test]
+    async fn send_frame_times_out_on_stuck_sink() {
+        let mut sink = PendingSink;
+        let start = Instant::now();
+        let status =
+            send_frame_with_timeout(&mut sink, Frame::text(b"x".to_vec()), 50).await;
+        assert!(matches!(status, SendStatus::TimedOut));
+        assert!(start.elapsed() < Duration::from_secs(2));
+    }
+
+    /// 正常 Sink 上发送应返回 Sent（含 timeout=0 禁用路径）
+    #[tokio::test]
+    async fn send_frame_succeeds_on_ready_sink() {
+        let mut sink = futures_util::sink::drain();
+        let status =
+            send_frame_with_timeout(&mut sink, Frame::text(b"a".to_vec()), 1_000).await;
+        assert!(matches!(status, SendStatus::Sent));
+
+        let status = send_frame_with_timeout(&mut sink, Frame::text(b"b".to_vec()), 0).await;
+        assert!(matches!(status, SendStatus::Sent));
     }
 
     /// network_changed() 应立即断开并重连，事件序列：

--- a/packages/catcher-ws/src/transport/ws_client.rs
+++ b/packages/catcher-ws/src/transport/ws_client.rs
@@ -35,6 +35,7 @@ enum WsCommand {
     Text(String),
     Binary(Vec<u8>),
     Close { code: u16, reason: String },
+    NetworkChanged,
 }
 
 // ── 公开类型 ──
@@ -83,6 +84,25 @@ impl WsHandle {
             })
     }
 
+    /// 通知库网络环境已发生变化（WiFi 切换、VPN 换节点、蜂窝/WiFi 切换等）。
+    ///
+    /// 旧连接在网络切换后通常处于半开状态，被动等待心跳超时需要 10-30 秒。
+    /// 调用此方法立即：
+    /// 1. 断开当前连接（不等心跳超时）
+    /// 2. 清空 DNS 缓存（新网络下解析结果可能不同）
+    /// 3. 重置重连退避计数，跳过退避延迟立即重连
+    /// 4. 多端点配置时重新竞速（新网络下最优端点可能不同）
+    ///
+    /// 重连期间正在等待退避的也会被打断并立即重试。
+    pub fn network_changed(&self) -> Result<(), CatcherError> {
+        self.cmd_tx
+            .send(WsCommand::NetworkChanged)
+            .map_err(|_| CatcherError::WsDisconnected {
+                code: 1006,
+                reason: "connection closed".into(),
+            })
+    }
+
     /// 返回连接的 URL（初始连接的 URL）
     pub fn url(&self) -> &str {
         &self.url
@@ -101,6 +121,7 @@ enum LoopOutcome {
     CleanClose,
     Disconnected { code: u16, reason: String },
     HeartbeatTimeout,
+    NetworkChanged,
 }
 
 fn application_compression_algorithm_name(
@@ -398,6 +419,26 @@ pub(crate) async fn connect_stream_with_resolver(
     Ok((stream, latency_ms))
 }
 
+/// 全量重连：多端点配置时重新竞速，单端点直接连接。
+/// 网络环境变化后调用 — 新网络下最优端点可能与之前不同。
+async fn connect_any_endpoint(
+    config: &WsClientConfig,
+    resolver: &SharedDnsResolver,
+) -> Result<(String, WsStream, u64), CatcherError> {
+    if config.urls.len() > 1 || config.race_count > 1 {
+        let racer = EndpointRacer::new(config.urls.clone(), config.race_count);
+        racer.race(config, resolver).await
+    } else {
+        let url = config
+            .urls
+            .first()
+            .cloned()
+            .ok_or_else(|| CatcherError::InvalidConfig("no WS URLs configured".into()))?;
+        let (stream, lat) = connect_stream_with_resolver(&url, config, resolver).await?;
+        Ok((url, stream, lat))
+    }
+}
+
 // ── 高级连接 ──
 
 impl WsTransport {
@@ -475,7 +516,7 @@ async fn connection_manager(
     event_tx: mpsc::UnboundedSender<WsEvent>,
     mut cmd_rx: mpsc::UnboundedReceiver<WsCommand>,
 ) {
-    let current_url = initial_url;
+    let mut current_url = initial_url;
     let mut stream_opt = Some(initial_stream);
     let mut reconnect_mgr = config
         .reconnect
@@ -563,6 +604,11 @@ async fn connection_manager(
                             let _ = writer.send(msg).await;
                             let _ = writer.close().await;
                             break LoopOutcome::CleanClose;
+                        }
+                        Some(WsCommand::NetworkChanged) => {
+                            // 旧网络上的连接大概率已半开，直接丢弃，不发 Close 帧
+                            // （在死网络上发送会阻塞到超时）
+                            break LoopOutcome::NetworkChanged;
                         }
                         None => break LoopOutcome::CleanClose,
                     }
@@ -655,6 +701,7 @@ async fn connection_manager(
         };
 
         // ── 处理 select loop 结果 ──
+        let network_changed = matches!(outcome, LoopOutcome::NetworkChanged);
         match outcome {
             LoopOutcome::CleanClose => break,
 
@@ -664,9 +711,37 @@ async fn connection_manager(
                     reason: "heartbeat timeout".into(),
                 });
             }
+            LoopOutcome::NetworkChanged => {
+                let _ = event_tx.send(WsEvent::Disconnected {
+                    code: 1006,
+                    reason: "network changed".into(),
+                });
+            }
             LoopOutcome::Disconnected { code, reason } => {
                 let _ = event_tx.send(WsEvent::Disconnected { code, reason });
             }
+        }
+
+        // ── 网络变化：清 DNS 缓存 + 跳过退避立即重连（即使未配置 reconnect）──
+        if network_changed {
+            dns_resolver.clear_cache();
+            if let Some(ref mut mgr) = reconnect_mgr {
+                mgr.reset();
+            }
+            let _ = event_tx.send(WsEvent::Reconnecting {
+                attempt: 0,
+                delay_ms: 0,
+            });
+            if let Ok((url, stream, lat)) = connect_any_endpoint(config, &dns_resolver).await {
+                current_url = url;
+                stream_opt = Some(stream);
+                first_latency = lat;
+                if let Some(ref mut mgr) = reconnect_mgr {
+                    mgr.on_connected();
+                }
+                continue;
+            }
+            // 立即重连失败 — 落入常规退避重连流程
         }
 
         // ── 尝试重连 ──
@@ -675,6 +750,9 @@ async fn connection_manager(
             let mut buffered_commands: Vec<WsCommand> = Vec::new();
             let mut reconnect_latency_ms: u64 = 0;
 
+            // 网络变化触发的重连：重新竞速全部端点（而非固守 current_url）
+            let mut race_endpoints = false;
+
             while let Some(delay) = mgr.on_disconnect() {
                 let attempt = mgr.attempt();
                 let _ = event_tx.send(WsEvent::Reconnecting {
@@ -682,29 +760,70 @@ async fn connection_manager(
                     delay_ms: delay,
                 });
 
-                tokio::time::sleep(Duration::from_millis(delay)).await;
-
-                // 排空待处理命令：Close 中止重连，其余缓存等待重放
+                // 退避等待 — 期间监听命令：Close 中止；NetworkChanged 打断
+                // 剩余延迟、重置退避计数立即重试；其余缓存等待重放
                 let mut abort = false;
-                loop {
-                    match cmd_rx.try_recv() {
-                        Ok(WsCommand::Close { .. }) => {
-                            abort = true;
-                            break;
+                let mut skip_backoff = false;
+                {
+                    let backoff_sleep = tokio::time::sleep(Duration::from_millis(delay));
+                    tokio::pin!(backoff_sleep);
+                    loop {
+                        tokio::select! {
+                            _ = &mut backoff_sleep => break,
+                            cmd = cmd_rx.recv() => match cmd {
+                                Some(WsCommand::Close { .. }) | None => {
+                                    abort = true;
+                                    break;
+                                }
+                                Some(WsCommand::NetworkChanged) => {
+                                    skip_backoff = true;
+                                    break;
+                                }
+                                Some(cmd) => buffered_commands.push(cmd),
+                            }
                         }
-                        Ok(cmd) => buffered_commands.push(cmd),
-                        Err(mpsc::error::TryRecvError::Empty) => break,
-                        Err(mpsc::error::TryRecvError::Disconnected) => {
-                            abort = true;
-                            break;
+                    }
+                }
+
+                // 排空剩余待处理命令
+                if !abort {
+                    loop {
+                        match cmd_rx.try_recv() {
+                            Ok(WsCommand::Close { .. }) => {
+                                abort = true;
+                                break;
+                            }
+                            Ok(WsCommand::NetworkChanged) => skip_backoff = true,
+                            Ok(cmd) => buffered_commands.push(cmd),
+                            Err(mpsc::error::TryRecvError::Empty) => break,
+                            Err(mpsc::error::TryRecvError::Disconnected) => {
+                                abort = true;
+                                break;
+                            }
                         }
                     }
                 }
                 if abort {
                     break;
                 }
+                if skip_backoff {
+                    dns_resolver.clear_cache();
+                    mgr.reset();
+                    race_endpoints = true;
+                }
 
-                match connect_stream_with_resolver(&current_url, config, &dns_resolver).await {
+                let connect_result = if race_endpoints {
+                    connect_any_endpoint(config, &dns_resolver)
+                        .await
+                        .map(|(url, stream, lat)| {
+                            current_url = url;
+                            (stream, lat)
+                        })
+                } else {
+                    connect_stream_with_resolver(&current_url, config, &dns_resolver).await
+                };
+
+                match connect_result {
                     Ok((stream, lat)) => {
                         stream_opt = Some(stream);
                         reconnect_latency_ms = lat;
@@ -732,7 +851,7 @@ async fn connection_manager(
                                         let _ = futures_util::SinkExt::send(&mut stream, msg).await;
                                     }
                                 }
-                                WsCommand::Close { .. } => {}
+                                WsCommand::Close { .. } | WsCommand::NetworkChanged => {}
                             }
                         }
                         stream_opt = Some(stream);
@@ -979,6 +1098,132 @@ mod tests {
         drop(result);
         bad_server.abort();
         let _ = good_server.await.unwrap();
+    }
+
+    /// network_changed() 应立即断开并重连，事件序列：
+    /// Connected → Disconnected("network changed") → Reconnecting(0) → Connected
+    #[tokio::test]
+    async fn network_changed_triggers_immediate_reconnect() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        // 服务器接受两次连接（初始 + 网络变化后的重连）
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                // 保持连接存活，直到对端断开
+                tokio::spawn(async move {
+                    let mut ws = ws;
+                    while let Some(Ok(_)) = ws.next().await {}
+                });
+            }
+        });
+
+        let config = WsClientConfig {
+            urls: vec![format!("ws://127.0.0.1:{port}")],
+            handshake_timeout_ms: 1_000,
+            reconnect: Some(ReconnectConfig {
+                initial_delay_ms: 60_000, // 故意设很大：验证重连没有走退避延迟
+                max_delay_ms: 60_000,
+                backoff_multiplier: 2.0,
+                max_attempts: 5,
+            }),
+            ..Default::default()
+        };
+
+        let (handle, mut rx) = WsTransport::connect(&config).await.unwrap();
+
+        // 初始 Connected
+        let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(first, WsEvent::Connected { .. }));
+
+        handle.network_changed().unwrap();
+
+        // Disconnected("network changed")
+        let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match ev {
+            WsEvent::Disconnected { reason, .. } => assert_eq!(reason, "network changed"),
+            other => panic!("expected Disconnected, got {other:?}"),
+        }
+
+        // Reconnecting(attempt=0, delay=0) — 立即重连，无退避
+        let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        match ev {
+            WsEvent::Reconnecting { attempt, delay_ms } => {
+                assert_eq!(attempt, 0);
+                assert_eq!(delay_ms, 0);
+            }
+            other => panic!("expected Reconnecting, got {other:?}"),
+        }
+
+        // 2 秒内重新 Connected（initial_delay 是 60 秒，证明跳过了退避）
+        let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(ev, WsEvent::Connected { .. }));
+
+        let _ = handle.close(1000, "done");
+        let _ = server.await;
+    }
+
+    /// 未配置 reconnect 时 network_changed() 也应执行一次立即重连
+    #[tokio::test]
+    async fn network_changed_reconnects_without_reconnect_config() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                tokio::spawn(async move {
+                    let mut ws = ws;
+                    while let Some(Ok(_)) = ws.next().await {}
+                });
+            }
+        });
+
+        let config = WsClientConfig {
+            urls: vec![format!("ws://127.0.0.1:{port}")],
+            handshake_timeout_ms: 1_000,
+            reconnect: None,
+            ..Default::default()
+        };
+
+        let (handle, mut rx) = WsTransport::connect(&config).await.unwrap();
+        let first = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(first, WsEvent::Connected { .. }));
+
+        handle.network_changed().unwrap();
+
+        // Disconnected → Reconnecting → Connected
+        let mut got_connected = false;
+        for _ in 0..3 {
+            let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            if matches!(ev, WsEvent::Connected { .. }) {
+                got_connected = true;
+                break;
+            }
+        }
+        assert!(got_connected, "should reconnect even without reconnect config");
+
+        let _ = handle.close(1000, "done");
+        let _ = server.await;
     }
 
     /// 验证 build_request 自动声明应用层压缩能力

--- a/packages/catcher-ws/src/types/ws.rs
+++ b/packages/catcher-ws/src/types/ws.rs
@@ -194,6 +194,13 @@ pub struct WsClientConfig {
     #[serde(alias = "handshakeTimeoutMs", default = "default_handshake_timeout")]
     pub handshake_timeout_ms: u64,
 
+    /// 单帧发送超时（毫秒，0 = 不限制）。
+    /// 网络切换后连接变成半开时，发送会阻塞到 TCP 重传超时（分钟级）并
+    /// 卡住整个事件循环（包括 network_changed 命令的处理）。超时后判定
+    /// 断线，进入重连流程。
+    #[serde(alias = "sendTimeoutMs", default = "default_send_timeout")]
+    pub send_timeout_ms: u64,
+
     /// 最大 payload 大小（字节）
     #[serde(alias = "maxPayloadBytes", default = "default_max_payload")]
     pub max_payload_bytes: u64,
@@ -219,6 +226,10 @@ pub struct WsClientConfig {
     pub dns: Option<DnsConfig>,
 }
 
+fn default_send_timeout() -> u64 {
+    10_000
+}
+
 fn default_deflate_threshold() -> u32 {
     1024
 }
@@ -242,6 +253,7 @@ impl Default for WsClientConfig {
             deflate_threshold_bytes: default_deflate_threshold(),
             application_compression: None,
             handshake_timeout_ms: default_handshake_timeout(),
+            send_timeout_ms: default_send_timeout(),
             max_payload_bytes: default_max_payload(),
             reconnect: None,
             heartbeat: None,

--- a/packages/catcher-ws/src/ws/reconnect.rs
+++ b/packages/catcher-ws/src/ws/reconnect.rs
@@ -66,6 +66,16 @@ impl ReconnectManager {
         self.current_delay_ms = 0;
     }
 
+    /// 重置重试计数与退避延迟，保留当前状态。
+    ///
+    /// 网络环境变化（WiFi 切换 / VPN 换节点）时调用：之前的失败是旧网络
+    /// 造成的，新网络应该从头开始计数，避免带着累积的退避延迟和已耗尽
+    /// 的次数进入新环境。
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+        self.current_delay_ms = 0;
+    }
+
     /// 当前状态
     pub fn state(&self) -> WsState {
         self.state
@@ -150,6 +160,19 @@ mod tests {
         mgr.on_connected();
         assert_eq!(mgr.state(), WsState::Connected);
         assert!(!mgr.is_exhausted());
+    }
+
+    #[test]
+    fn reset_clears_attempt_and_delay() {
+        let mut mgr = ReconnectManager::new(test_config());
+        for _ in 0..5 {
+            mgr.on_disconnect();
+        }
+        // 已用尽 5 次，reset 后重新可用且从 initial_delay 开始
+        mgr.reset();
+        let delay = mgr.on_disconnect();
+        assert_eq!(delay, Some(500));
+        assert_eq!(mgr.attempt(), 1);
     }
 
     #[test]

--- a/packages/catcher_core/lib/src/ffi_bindings.dart
+++ b/packages/catcher_core/lib/src/ffi_bindings.dart
@@ -188,6 +188,15 @@ typedef CatcherWsCloseDart = void Function(
   FfiStringNative reason,
 );
 
+/// catcher_ws_network_changed(handle) → FfiResult
+/// 通知网络环境变化：立即断开重连，跳过退避延迟
+typedef CatcherWsNetworkChangedNative = FfiResultNative Function(
+  Pointer<Void> handle,
+);
+typedef CatcherWsNetworkChangedDart = FfiResultNative Function(
+  Pointer<Void> handle,
+);
+
 /// catcher_ws_destroy(handle)
 typedef CatcherWsDestroyNative = Void Function(Pointer<Void> handle);
 typedef CatcherWsDestroyDart = void Function(Pointer<Void> handle);
@@ -259,6 +268,11 @@ typedef CatcherQualityHistoryDart = Pointer<Char> Function();
 /// catcher_http_client_cancel_all(handle)
 typedef CatcherHttpClientCancelAllNative = Void Function(Pointer<Void> handle);
 typedef CatcherHttpClientCancelAllDart = void Function(Pointer<Void> handle);
+
+/// catcher_http_network_changed(handle) → i32 (0=success, 1=invalid handle, 2=rebuild failed)
+/// 通知网络环境变化：清 DNS 缓存、重建连接池、重置熔断器
+typedef CatcherHttpNetworkChangedNative = Int32 Function(Pointer<Void> handle);
+typedef CatcherHttpNetworkChangedDart = int Function(Pointer<Void> handle);
 
 /// catcher_http_circuit_breaker_state(handle) → *mut c_char (JSON, caller frees via catcher_free_data)
 typedef CatcherHttpCircuitBreakerStateNative = Pointer<Char> Function(

--- a/packages/catcher_core/lib/src/http_client.dart
+++ b/packages/catcher_core/lib/src/http_client.dart
@@ -33,6 +33,7 @@ class CatcherHttpClient {
   late final CatcherFreeEventDataDart _freeEventDataFn;
   late final CatcherFreeDataDart _freeDataFn;
   CatcherHttpClientCancelAllDart? _cancelAllFn;
+  CatcherHttpNetworkChangedDart? _networkChangedFn;
   CatcherHttpCircuitBreakerStateDart? _circuitBreakerStateFn;
   CatcherHttpMetricsDart? _metricsFn;
   CatcherHttpAdaptiveTimeoutConfigDart? _adaptiveTimeoutFn;
@@ -66,6 +67,13 @@ class CatcherHttpClient {
           CatcherHttpClientCancelAllDart>('catcher_http_client_cancel_all');
     } catch (_) {
       _cancelAllFn = null;
+    }
+
+    try {
+      _networkChangedFn = _lib.lookupFunction<CatcherHttpNetworkChangedNative,
+          CatcherHttpNetworkChangedDart>('catcher_http_network_changed');
+    } catch (_) {
+      _networkChangedFn = null;
     }
 
     try {
@@ -166,6 +174,26 @@ class CatcherHttpClient {
     final bodyBytes = body != null ? utf8.encode(jsonEncode(body)) : null;
     return _execute('PATCH', path, bodyBytes, contentType,
         headers: headers, timeoutMs: timeoutMs);
+  }
+
+  /// 通知客户端网络环境已变化（WiFi 切换 / VPN 换节点 / 蜂窝切换等）。
+  ///
+  /// 在 connectivity_plus 等插件的网络变化回调中调用。清空 DNS 缓存、
+  /// 重建连接池（丢弃可能半开的 keep-alive 连接）、重置熔断器 — 新请求
+  /// 立即走新网络上的全新连接。飞行中的请求不受影响。
+  void networkChanged() {
+    final fn = _networkChangedFn;
+    if (fn == null) {
+      throw StateError(
+          'networkChanged() requires a rebuilt native library (>= 0.4)');
+    }
+    if (_handle == null || _handle == nullptr) {
+      throw StateError('HTTP client has been disposed');
+    }
+    final code = fn(_handle!);
+    if (code != 0) {
+      throw StateError('networkChanged failed with code $code');
+    }
   }
 
   /// Cancel all in-flight requests on this client (page-exit scenario).

--- a/packages/catcher_core/lib/src/http_client.dart
+++ b/packages/catcher_core/lib/src/http_client.dart
@@ -185,7 +185,8 @@ class CatcherHttpClient {
     final fn = _networkChangedFn;
     if (fn == null) {
       throw StateError(
-          'networkChanged() requires a rebuilt native library (>= 0.4)');
+          'networkChanged() requires a native library that exports '
+          'catcher_http_network_changed — rebuild catcher-ffi');
     }
     if (_handle == null || _handle == nullptr) {
       throw StateError('HTTP client has been disposed');

--- a/packages/catcher_core/lib/src/ws_client.dart
+++ b/packages/catcher_core/lib/src/ws_client.dart
@@ -146,7 +146,8 @@ class CatcherWsClient {
     final fn = _networkChanged;
     if (fn == null) {
       throw StateError(
-          'networkChanged() requires a rebuilt native library (>= 0.4)');
+          'networkChanged() requires a native library that exports '
+          'catcher_ws_network_changed — rebuild catcher-ffi');
     }
     final result = fn(_handle!);
     _checkResult(result);

--- a/packages/catcher_core/lib/src/ws_client.dart
+++ b/packages/catcher_core/lib/src/ws_client.dart
@@ -397,6 +397,10 @@ class WsClientConfig {
   final List<String> urls;
   final bool perMessageDeflate;
   final int handshakeTimeoutMs;
+
+  /// 单帧发送超时（毫秒，0 = 不限制）。
+  /// 半开连接上的发送超时后判定断线并进入重连流程。
+  final int sendTimeoutMs;
   final int maxPayloadBytes;
   final WsReconnectConfig? reconnect;
   final WsHeartbeatConfig? heartbeat;
@@ -412,6 +416,7 @@ class WsClientConfig {
     required this.urls,
     this.perMessageDeflate = true,
     this.handshakeTimeoutMs = 15000,
+    this.sendTimeoutMs = 10000,
     this.maxPayloadBytes = 67108864, // 64MB
     this.reconnect,
     this.heartbeat,
@@ -428,6 +433,7 @@ class WsClientConfig {
         'urls': urls,
         'per_message_deflate': perMessageDeflate,
         'handshake_timeout_ms': handshakeTimeoutMs,
+        'send_timeout_ms': sendTimeoutMs,
         'max_payload_bytes': maxPayloadBytes,
         if (reconnect != null) 'reconnect': reconnect!.toJson(),
         if (heartbeat != null) 'heartbeat': heartbeat!.toJson(),

--- a/packages/catcher_core/lib/src/ws_client.dart
+++ b/packages/catcher_core/lib/src/ws_client.dart
@@ -28,6 +28,7 @@ class CatcherWsClient {
   late final CatcherWsSendTextDart _sendText;
   late final CatcherWsSendBinaryDart _sendBinary;
   late final CatcherWsCloseDart _close;
+  late final CatcherWsNetworkChangedDart? _networkChanged;
   late final CatcherWsDestroyDart _destroy;
   late final CatcherFreeResultDart _freeResultFn;
   late final CatcherFreeEventDataDart _freeEventDataFn;
@@ -50,6 +51,15 @@ class CatcherWsClient {
             'catcher_ws_send_binary');
     _close = lib.lookupFunction<CatcherWsCloseNative, CatcherWsCloseDart>(
         'catcher_ws_close');
+    // 兼容旧版本动态库：符号不存在时降级为 null
+    CatcherWsNetworkChangedDart? networkChangedFn;
+    try {
+      networkChangedFn = lib.lookupFunction<CatcherWsNetworkChangedNative,
+          CatcherWsNetworkChangedDart>('catcher_ws_network_changed');
+    } catch (_) {
+      networkChangedFn = null;
+    }
+    _networkChanged = networkChangedFn;
     _destroy = lib.lookupFunction<CatcherWsDestroyNative, CatcherWsDestroyDart>(
         'catcher_ws_destroy');
 
@@ -123,6 +133,22 @@ class CatcherWsClient {
     }
     final result = _sendBinary(_handle!, ptr, data.length);
     malloc.free(ptr);
+    _checkResult(result);
+  }
+
+  /// 通知客户端网络环境已变化（WiFi 切换 / VPN 换节点 / 蜂窝切换等）。
+  ///
+  /// 在 connectivity_plus 等插件的网络变化回调中调用。立即丢弃当前
+  /// （大概率已半开的）连接、清空 DNS 缓存、重置重连退避并马上重连 —
+  /// 无需被动等待 10-30 秒心跳超时。多端点配置时重新竞速。
+  void networkChanged() {
+    _ensureHandle();
+    final fn = _networkChanged;
+    if (fn == null) {
+      throw StateError(
+          'networkChanged() requires a rebuilt native library (>= 0.4)');
+    }
+    final result = fn(_handle!);
     _checkResult(result);
   }
 


### PR DESCRIPTION
## Summary

网络环境切换（WiFi 切换热点、WiFi ↔ 蜂窝、VPN 连接/断开/换节点）后，旧连接静默变成半开连接。当前完全依赖被动检测：WS 心跳超时要 10-30 秒，HTTP 连接池靠 TCP keepalive 探针（20s），DNS 缓存最长 300 秒才刷新。`docs/research/expandation/02-network-env.md` 把 "VPN 网络变化检测" 列为高优先级缺失（第 8 条）。

本 PR 新增 `networkChanged()` API：宿主 App 从 OS 拿到网络变化信号（NWPathMonitor / ConnectivityManager / connectivity_plus / navigator.onLine）后主动通知 catcher，立即完成恢复，不再等被动超时。

**catcher-dns**
- 新增 `DnsResolver::clear_cache()`：同时失效 moka 缓存层和 hickory 内部缓存；`host_mapping` 静态配置不受影响；无 hickory feature 时为 no-op

**catcher-ws — `WsHandle::network_changed()`**
- 立即丢弃当前连接（不发 Close 帧，死网络上发送会阻塞）
- 清空 DNS 缓存，重置重连退避计数（`ReconnectManager::reset()`）
- 跳过退避延迟立即重连；正在退避 sleep 中也会被打断（select on cmd channel）
- 多端点配置时重新竞速 —— 新网络下最优端点可能不同
- 未配置 reconnect 也执行一次立即重连
- 复用现有事件（`Disconnected "network changed"` → `Reconnecting attempt=0` → `Connected`），无新增事件变体，不破坏现有消费者

**catcher-http — `HttpTransport::network_changed()`**
- 清空共享 DNS 解析器缓存（解析器改为构建一次、跨重建复用）
- 重建 reqwest 客户端，丢弃整个旧连接池（inner client 改为 `RwLock` 热替换）
- 重置熔断器 —— 切换期间的失败不惩罚新网络
- 飞行中请求持有旧 client 克隆，不受影响

**全平台绑定**
- C ABI：`catcher_ws_network_changed` / `catcher_http_network_changed`
- napi + TS wrapper：`networkChanged()`（http/ws）
- UniFFI（Kotlin/Swift）：`network_changed()`
- Dart（catcher_core）：`networkChanged()`，旧动态库缺符号时优雅降级报错

**文档**
- `docs/user-manual/resilience.md` 新增第七节：问题背景、行为说明、6 个平台的用法示例、防抖建议
- `02-network-env.md` 高优先级缺失第 8 条标记为已实现

## 验证

- `cargo test --workspace`：207 passed, 0 failed（新增 7 个测试：DNS 缓存清空、退避重置、WS 立即重连跳过 60s 退避、无 reconnect 配置重连、HTTP 重建后请求正常、熔断器重置、幂等性）
- `cargo clippy --workspace --all-targets -- -D warnings`：clean
- `pnpm typecheck`：全部 7 个 TS 包通过（napi build 后 `index.d.ts` 已含 `networkChanged()`）
- `dart analyze lib`（catcher_core）：No issues found

## 已知问题（与本 PR 无关）

`catcher-ffi` 的 `http_test` 套件整跑时在 `h11_cancel_all_with_per_request` 附近 SIGSEGV，单跑每个测试均通过。**master（7d82cc7）上完全相同复现**，是预先存在的跨测试污染（FFI 回调 + 全局 runtime），建议另开 issue 跟踪。

## 兼容性

纯增量 API，无 breaking change。不调用 `networkChanged()` 时行为与之前完全一致（心跳/keepalive 被动兜底仍然有效）。