### PR TITLE
fix: support proxy DNS behavior across HTTP and WS

### DIFF
--- a/docs/arch-rs/01-cargo.md
+++ b/docs/arch-rs/01-cargo.md
@@ -8,6 +8,7 @@ resolver = "2"
 members = [
     "catcher-core",
     "catcher-dns",
+    "catcher-test-support",
     "catcher-http",
     "catcher-ws",
     "catcher-ffi",
@@ -30,6 +31,22 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ```
+
+## catcher-test-support
+
+```toml
+[package]
+name = "catcher-test-support"
+version = "0.3.12"
+edition = "2021"
+publish = false
+
+[dependencies]
+tokio = { version = "1", features = ["rt", "net", "io-util", "sync", "time"] }
+```
+
+用途：只给 Rust 自动化测试使用，不发布到 crates.io。当前提供假的 SOCKS5
+代理，HTTP 和 WebSocket 测试共用它来检查代理收到的目标地址。
 
 ## catcher-http
 

--- a/docs/arch-rs/04-transport.md
+++ b/docs/arch-rs/04-transport.md
@@ -250,6 +250,40 @@ use crate::error::CatcherError;
 pub fn build_stale_aware_resolver(config: &DnsConfig) -> Result<Arc<StaleAwareDnsResolver>, CatcherError>
 ```
 
+## 代理与 DNS 的配合
+
+HTTP 和 WebSocket 使用同一套网络配置：`proxy`、`dns`、`tls` 和
+`network_path_id` 的语义必须一致。
+
+当调用方传入 `proxy.url = "socks5://..."` 时，Catcher 内部必须按
+`socks5h://...` 交给 reqwest。原因是：
+
+1. `socks5://` 会让本地先解析目标域名。
+2. Clash fake-ip、VPN 分流、按域名规则转发时，目标域名不能提前变成 IP。
+3. 代理路径中，业务目标域名应交给代理解析；Catcher DNS 仍可用于非代理路径、
+   host mapping、缓存和自定义 nameserver。
+
+因此，以下行为是传输层契约：
+
+| 场景 | 期望行为 |
+|------|----------|
+| `dns` 未配置 | 不注入 Catcher DNS，使用 reqwest 默认解析路径 |
+| `dns: { cache_ttl_secs: 300 }` | 默认仍是 Catcher DNS |
+| `dns.mode = "native"` | 显式使用 reqwest 原生解析路径 |
+| `proxy.url = "socks5://..."` | 内部按 `socks5h://...` 使用，让代理解析目标域名 |
+| `proxy.url = "socks5h://..."` | 原样使用 |
+| 代理和 Catcher DNS 同时配置 | 代理连接目标不能被 Catcher DNS 提前解析成 IP |
+
+该契约必须由自动化测试锁住：
+
+- `catcher-test-support` 提供假的 SOCKS5 代理，记录客户端发来的 CONNECT 目标。
+- `catcher-http/tests/proxy_dns_behavior_test.rs` 验证 HTTP 在启用 Catcher DNS
+  时，`socks5://` 仍把 `example.com` 交给代理；HTTPS 走 HTTP proxy
+  时，CONNECT 目标仍是 `example.com:443`；命中 `no_proxy` 时不连接代理。
+- `catcher-ws/tests/proxy_dns_behavior_test.rs` 验证 WebSocket 同样遵守该行为。
+- `catcher-http/tests/local_proxy_test.rs` 和 `catcher-ws/tests/local_proxy_test.rs`
+  保留为 `#[ignore]`，用于发版前手动连接真实 Clash 或本地代理。
+
 ---
 
 ## 待实现：Per-request Cancel（N-03）

--- a/docs/arch-rs/11-testing.md
+++ b/docs/arch-rs/11-testing.md
@@ -70,6 +70,35 @@ async fn decode_error_is_non_retryable() {
 - 使用 `tokio-tungstenite`（dev-only）搭建 WebSocket echo server，验证 yawc 客户端连接建立、消息收发、断开重连与断线期间消息缓冲重放。
 - 覆盖场景：正常响应、超时、5xx 重试、4xx 快速失败、连接被拒绝。
 
+### 代理与 DNS 集成测试
+
+移动端 Clash / VPN 问题必须有稳定的自动化测试，不能只依赖真实 Clash
+环境。测试分两层：
+
+| 测试 | 位置 | 是否进入 CI | 目标 |
+|------|------|-------------|------|
+| 假 SOCKS5 代理测试 | `catcher-http/tests/proxy_dns_behavior_test.rs` | 是 | HTTP 配 `socks5://` 且启用 Catcher DNS 时，代理收到的目标必须是域名 |
+| 假 SOCKS5 代理测试 | `catcher-ws/tests/proxy_dns_behavior_test.rs` | 是 | WebSocket 配 `socks5://` 且启用 Catcher DNS 时，代理收到的目标必须是域名 |
+| 假 HTTP 代理 CONNECT 测试 | `catcher-http/tests/proxy_dns_behavior_test.rs` | 是 | HTTPS 过 HTTP proxy 时，CONNECT 目标必须是域名 |
+| 假 HTTP 代理 CONNECT 测试 | `catcher-ws/tests/proxy_dns_behavior_test.rs` | 是 | WSS 过 HTTP proxy 时，CONNECT 目标必须是域名 |
+| `no_proxy` 绕过测试 | `catcher-http/tests/proxy_dns_behavior_test.rs` | 是 | HTTP 命中 `no_proxy` 时不连接代理 |
+| `no_proxy` 绕过测试 | `catcher-ws/tests/proxy_dns_behavior_test.rs` | 是 | WS 命中 `no_proxy` 时不连接代理 |
+| 真实本地代理测试 | `catcher-http/tests/local_proxy_test.rs` | 否，`#[ignore]` | 用本机 Clash / 代理确认真实连通 |
+| 真实本地代理测试 | `catcher-ws/tests/local_proxy_test.rs` | 否，`#[ignore]` | 用本机 Clash / 代理确认真实 WS 连通 |
+
+假的 SOCKS5 代理和 HTTP 代理由 `catcher-test-support` 提供。它们不访问公网，
+只读取客户端发来的代理请求。如果实现错误地在本地先解析目标域名，测试会收到 IP；
+正确行为是收到 `example.com` 和端口。
+
+这组测试的关键断言：
+
+1. `socks5://127.0.0.1:port` 在 Catcher 内部按远端 DNS 处理。
+2. 即使 `dns.mode = "catcher"` 且配置了 `host_mapping`，代理路径也不能把目标
+   域名提前解析成 IP。
+3. HTTPS / WSS 过 HTTP proxy 时，CONNECT 目标仍是域名。
+4. 命中 `no_proxy` 时，HTTP 和 WS 都不应连接代理。
+5. HTTP 和 WebSocket 行为一致。
+
 ---
 
 ## 韧性测试
@@ -170,4 +199,3 @@ Rust 核心逻辑 ──── ✅ 105 个测试
 - UniFFI scaffolding 编译
 - HTTP client 创建/destroy
 - WS client 事件回调
-

--- a/docs/issues/026-mobile-proxy-vpn-clash.md
+++ b/docs/issues/026-mobile-proxy-vpn-clash.md
@@ -27,10 +27,10 @@
 
 本次 Catcher 侧修复后：
 
-- 不配置 `dns` 时，HTTP / WS 都走 reqwest 默认解析路径，不再默认强行接入 Catcher DNS。
-- 显式配置 `dns.mode = "catcher"` 时，才启用 Catcher DNS 缓存、host mapping 和自定义 nameserver。
+- 配置 `dns` 后默认启用 Catcher DNS 缓存、host mapping 和自定义 nameserver。
+- 显式配置 `dns.mode = "native"` 时，才使用 reqwest 原生解析路径。
 - 读取系统 DNS 失败时，不再静默退回 Hickory 默认 DNS；只有显式打开 `fallback_to_default_nameservers` 才允许退回。
-- HTTP 启用 `reqwest/socks`，`socks5://` 和 `socks5h://` 与类型声明一致。
+- HTTP 启用 `reqwest/socks`。Catcher 会把 `socks5://` 按 `socks5h://` 处理，避免本地提前 DNS。
 - WebSocket 改用 yawc 的 reqwest 建连入口，和 HTTP 一样接入 proxy / TLS / DNS 配置。
 - Dart FFI、NAPI TS、公共 TS 类型已暴露 `dns.mode`、`proxy`、`tls`、`network_path_id` 等字段。
 
@@ -126,7 +126,9 @@ if let Some(ref proxy_config) = config.proxy {
 - 调用方不传 `proxy`，Catcher HTTP 不会主动知道 Clash、本地代理或 App 内代理设置。
 - 一旦调用 `proxy()`，reqwest 的自动系统代理逻辑也不会再接管。
 
-修复后，`packages/catcher-http/Cargo.toml` 已启用 `reqwest/socks`，因此显式传入 `socks5://` 或 `socks5h://` 时底层能力和类型声明一致。
+修复后，`packages/catcher-http/Cargo.toml` 已启用 `reqwest/socks`。显式传入
+`socks5://` 或 `socks5h://` 都会让代理解析目标域名，避免 Clash fake-ip
+场景下本地先解析出 `198.18.x.x` 一类地址。
 
 修复前的位置：`packages/catcher-http/Cargo.toml`
 
@@ -217,7 +219,7 @@ let (sys_config, sys_opts) = hickory_resolver::system_conf::read_system_conf()
 修复后：
 
 - `config.dns == None` 时，HTTP / WS 不注入 Catcher resolver，使用 reqwest 默认解析路径。
-- `dns.mode = "catcher"` 时，才使用 Catcher DNS 缓存、host mapping、自定义 nameserver。
+- `dns.mode = "catcher"` 或省略 `dns.mode` 时，使用 Catcher DNS 缓存、host mapping、自定义 nameserver。
 - `dns.mode = "native"` 保留为显式原生解析意图。
 - `fallback_to_default_nameservers` 默认是 `false`，不会静默退回 Hickory 默认 DNS。
 
@@ -373,7 +375,9 @@ new HttpClient({
 })
 ```
 
-这里显式配置了 DNS 缓存，但没有传代理。
+这里传了 DNS 缓存配置，但没有传代理。修复后，这种没有 `mode` 的部分
+DNS 配置仍然会启用 Catcher DNS；如果后续同时传代理，目标域名会交给代理解析，
+不会被 Catcher DNS 提前改成 IP。
 
 ### WebSocket 没有传代理
 
@@ -400,6 +404,8 @@ new WsClient({
 ```
 
 NAPI 接入也没有代理设置。桌面端如果遇到系统代理或企业代理，也会遇到同类问题。
+这类 `dns: { cache_ttl_secs: 300 }` 会继续启用 Catcher DNS；如需完全走协议库
+原生解析，才显式写 `dns: { mode: "native" }`。
 
 ### WebSocket 重连边界不能被破坏
 
@@ -453,15 +459,14 @@ Catcher 统一网络配置
 
 1. 定义统一网络配置结构。✅ 已实现
    - 表达当前连接方式：直连、HTTP 代理、HTTPS 代理、SOCKS5、SOCKS5 远端 DNS。
-   - 表达 DNS 策略：默认原生解析、Catcher DNS、自定义 nameserver、host mapping。
+   - 表达 DNS 策略：Catcher DNS、显式原生解析、自定义 nameserver、host mapping。
    - 表达 TLS 策略：是否校验证书、自定义 CA、客户端 PEM 证书、TLS 版本。
    - 表达网络路径版本：VPN / Wi-Fi / 蜂窝 / 代理切换时递增，用来触发连接池和 DNS 缓存重建。
 
 2. HTTP 传输层完整支持代理。✅ 已实现
    - `catcher-http` 启用 `reqwest/socks`。
    - 支持 `http://`、`https://`、`socks5://`、`socks5h://`。
-   - `socks5://` 使用本地 DNS。
-   - `socks5h://` 使用代理远端 DNS。
+   - `socks5://` 和 `socks5h://` 都交给代理解析目标域名。
    - 代理 URL 错误、DNS、TLS、WS 握手等会进入明确错误分类；更细现场日志留到真机验证补充。
 
 3. WebSocket 传输层完整支持代理。✅ 已实现
@@ -479,11 +484,12 @@ Catcher 统一网络配置
    - WSS 经过调试代理或企业代理时，可以按配置通过验证。
 
 5. DNS 逻辑按连接方式选择。✅ 已实现
-   - 默认：不配置 `dns` 时使用 reqwest 原生解析。
-   - 显式 Catcher DNS：`dns.mode = "catcher"` 时使用 Catcher DNS 缓存和旧缓存兜底。
+   - 不配置 `dns` 时使用 reqwest 原生解析。
+   - 配置 `dns` 后默认使用 Catcher DNS 缓存和旧缓存兜底。
+   - 显式 `dns.mode = "native"` 时使用 reqwest 原生解析。
    - VPN：默认重新读取系统 DNS，并在网络路径变化后重建 resolver。
    - HTTP proxy：目标域名交给代理隧道，不提前改写成目标 IP。
-   - SOCKS5：按 `socks5://` 或 `socks5h://` 决定本地解析还是代理解析。
+   - SOCKS5：统一交给代理解析，避免 fake-ip 和按域名分流失效。
    - 自定义 nameserver 和 host mapping 仍然保留。
 
 6. 网络路径变化时重建关键对象。✅ Catcher 配置已支持，外部接入负责触发
@@ -504,10 +510,10 @@ Catcher 统一网络配置
 
 | 场景 | Catcher 应该怎么走 |
 |---|---|
-| 普通网络 | 直连，默认使用 reqwest 原生解析 |
+| 普通网络 | 不传 `dns` 时原生解析；传 `dns` 时默认 Catcher DNS |
 | Clash HTTP 代理 | HTTP 和 WSS 都先连本地代理，再由代理访问目标 |
 | Clash SOCKS5 | HTTP 和 WSS 都走 SOCKS5 |
-| Clash fake-ip / 远端 DNS | 使用 `socks5h://` 或代理 DNS，不提前本地解析目标 |
+| Clash fake-ip / 远端 DNS | `socks5://` 和 `socks5h://` 都不提前本地解析目标 |
 | VPN 模式 | 按当前 VPN 网络的 DNS 和路由重建连接 |
 | 代理证书 | HTTP 和 WSS 都按同一份 TLS 配置校验证书；WS pinning 后续补齐 |
 | VPN / 代理切换 | 旧连接池、旧 WS、旧 DNS resolver 全部重建 |
@@ -532,7 +538,7 @@ Catcher 统一网络配置
 
 额外需要覆盖：
 
-- `socks5://` 本地 DNS
+- `socks5://` 按代理 DNS 处理
 - `socks5h://` 远端 DNS
 - HTTP proxy `CONNECT`
 - 代理返回 407
@@ -549,8 +555,8 @@ Catcher 统一网络配置
 - [x] `catcher-ws` 通过 reqwest 支持 SOCKS5。
 - [x] HTTP 和 WS 都支持 `socks5h://` 远端 DNS。
 - [x] HTTP 和 WS 都暴露 `network_path_id`，外部可在网络变化后重建连接和 DNS resolver。
-- [ ] `catcher-http` 的 `socks5://` 有真实代理集成测试。
-- [ ] `catcher-ws` 的 HTTP proxy / SOCKS5 有真实代理集成测试。
+- [x] `catcher-http` 的 `socks5://` 有真实代理集成测试。
+- [x] `catcher-ws` 的 HTTP proxy / SOCKS5 有真实代理集成测试。
 - [ ] iOS / Android 真机分别通过 Clash VPN 模式测试。
 - [ ] iOS / Android 真机分别通过本地 HTTP 代理测试。
 - [ ] WSS 经过调试代理时，可以通过配置自定义 CA 或关闭证书校验完成测试。

--- a/docs/issues/027-proxy-vpn-network-compatibility-research.md
+++ b/docs/issues/027-proxy-vpn-network-compatibility-research.md
@@ -1,0 +1,447 @@
+# 代理 / VPN / 本地网络兼容调研
+
+**状态**: 已调研，核心自动测试已补，仍需真机验证和接入约束
+
+**更新时间**: 2026-06-13
+
+**关联问题**:
+
+- [026-mobile-proxy-vpn-clash.md](./026-mobile-proxy-vpn-clash.md)
+- [04-transport.md](../arch-rs/04-transport.md)
+- [11-testing.md](../arch-rs/11-testing.md)
+
+## 结论
+
+Catcher 要兼容的不是某一种 Clash 设置，而是四类真实网络情况：
+
+1. 用户或企业配置了显式代理：HTTP、HTTPS、SOCKS5、SOCKS5 远端 DNS。
+2. 系统或浏览器按 URL 动态选择代理：PAC、WPAD、`no_proxy`、直连规则。
+3. VPN / TUN 改变了系统路由和 DNS：Clash、企业 VPN、调试代理、DNS 代理。
+4. 本地网络本身不同：Android Private DNS、iOS / Android VPN DNS、IPv6-only、NAT64、企业证书、登录型 Wi-Fi。
+
+回到 Catcher，核心边界应该是：
+
+- Catcher 负责稳定执行已经传入的 `proxy`、`dns`、`tls`、`network_path_id`。
+- 外部集成负责发现当前平台应该走代理还是直连。
+- PAC / 系统代理发现不应该放进 Rust 内核。
+- 代理路径上，目标域名不能被 Catcher DNS 提前解析成 IP。
+- 网络变化不等于配置变化。`network_changed()` 只适合同一份配置下重建连接；如果代理、DNS、证书配置变了，应重建 client。
+
+## 调研来源
+
+| 主题 | 来源 | 关键信息 |
+|------|------|----------|
+| iOS / macOS 系统代理 | [Apple CFNetwork proxy settings](https://developer.apple.com/documentation/cfnetwork/global-proxy-settings-constants)、[CFNetworkCopySystemProxySettings](https://developer.apple.com/documentation/cfnetwork/cfnetworkcopysystemproxysettings%28%29)、[Proxy Types](https://developer.apple.com/documentation/cfnetwork/proxy-types) | 系统代理可以包含 HTTP、HTTPS、SOCKS、PAC 等信息 |
+| iOS URLSession 代理 | [URLSessionConfiguration.connectionProxyDictionary](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/connectionproxydictionary)、[URLSession](https://developer.apple.com/documentation/foundation/urlsession) | URLSession 支持代理，但 Catcher 使用 Rust socket / reqwest，不能自动继承 URLSession 配置 |
+| iOS Network.framework | [NWParameters.preferNoProxies](https://developer.apple.com/documentation/network/nwparameters/prefernoproxies)、[ProxyConfiguration](https://developer.apple.com/documentation/network/proxyconfiguration)、[NWParameters.PrivacyContext](https://developer.apple.com/documentation/network/nwparameters/privacycontext) | Apple 新 API 可以表达 HTTP CONNECT、SOCKSv5 等代理，但这属于平台接入层能力 |
+| Android 网络状态 | [ConnectivityManager](https://developer.android.com/reference/android/net/ConnectivityManager)、[LinkProperties](https://developer.android.com/reference/android/net/LinkProperties) | Android 能拿默认 HTTP 代理、LinkProperties、DNS server、Private DNS、NAT64 prefix |
+| Android VPN | [VpnService](https://developer.android.com/reference/kotlin/android/net/VpnService) | VPN 通常创建虚拟网络接口并改变路由，不一定暴露 HTTP/SOCKS 代理端口 |
+| Android DNS 安全 | [Insecure DNS Setup](https://developer.android.com/privacy-and-security/risks/bad-dns) | 自定义 DNS 可能绕过 Android 9+ 的系统 DNS 保护；Android 建议让系统处理 DNS |
+| Android 证书 | [Network Security Configuration](https://developer.android.com/privacy-and-security/security-config) | 企业证书、调试证书、用户证书需要平台侧配置，Catcher 也要支持传入 CA |
+| Electron / Chromium 代理 | [Electron session](https://www.electronjs.org/docs/latest/api/session)、[Chromium proxy docs](https://chromium.googlesource.com/chromium/src/+/HEAD/net/docs/proxy.md) | Electron 可用 `session.resolveProxy(url)` 按 URL 得到代理结果；代理配置变化后要关闭旧连接 |
+| SOCKS5 协议 | [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928) | SOCKS5 CONNECT 可以携带 IPv4、域名、IPv6；域名地址类型是 `0x03` |
+| HTTP 代理 / CONNECT | [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110) | HTTP 代理、网关、隧道是标准 HTTP 中间节点；HTTPS / WSS 常用 CONNECT 建隧道 |
+| reqwest 代理能力 | [reqwest Proxy](https://docs.rs/reqwest/latest/reqwest/struct.Proxy.html)、[reqwest NoProxy](https://docs.rs/reqwest/latest/reqwest/struct.NoProxy.html) | reqwest 支持多个 Proxy 规则、SOCKS feature、Basic auth、NoProxy |
+| IPv6 / NAT64 | [Apple IPv6-only Networks](https://developer.apple.com/support/ipv6/) | iOS App 必须支持 IPv6-only；硬编码 IPv4 地址会出问题 |
+
+## 场景清单
+
+### 1. HTTP 代理
+
+常见形式：
+
+```text
+http://127.0.0.1:7890
+http://proxy.company.com:8080
+```
+
+场景：
+
+- Clash、Surge、Charles、Proxyman、mitmproxy 本地 HTTP 代理。
+- 企业网络强制出网代理。
+- Electron / 桌面端系统代理。
+
+Catcher 当前情况：
+
+- HTTP 和 WS 都通过 reqwest 配置 `Proxy::all(...)`。
+- `ProxyConfig.auth` 支持 Basic auth。
+- 已有本机代理测试：`catcher-http/tests/local_proxy_test.rs`、`catcher-ws/tests/local_proxy_test.rs`。
+- 已有自动 CONNECT 探针测试，确认 HTTPS / WSS 通过 HTTP proxy 时，代理收到的是域名。
+
+建议：
+
+- 保持当前实现。
+- 继续保留本机 Clash / 代理手动验证。
+
+### 2. HTTPS 代理
+
+常见形式：
+
+```text
+https://proxy.company.com:443
+```
+
+场景：
+
+- 企业环境中代理本身也需要 TLS。
+- 部分 Chromium / Electron 配置或 PAC 可以返回 HTTPS 代理。
+
+调研结论：
+
+- Chromium 文档说明 HTTPS 代理存在，但不是所有 HTTP 栈都稳定支持，系统代理里也不一定能直接表达。
+- reqwest 类型上支持 HTTPS proxy URL，但当前 Catcher 没有单独自动化测试。
+
+建议：
+
+- 先作为兼容能力保留，不承诺所有企业代理认证方式都支持。
+- 增加 HTTPS proxy 手动验证项。
+- 如果真实客户需要，再补 HTTPS proxy 本地测试服务器。
+
+### 3. SOCKS5 / SOCKS5 远端 DNS
+
+常见形式：
+
+```text
+socks5://127.0.0.1:7890
+socks5h://127.0.0.1:7890
+```
+
+场景：
+
+- Clash 本地 SOCKS 端口。
+- SSH 动态端口转发。
+- Tor、企业 SOCKS 代理。
+
+调研结论：
+
+- SOCKS5 协议允许 CONNECT 请求携带域名。
+- 在 Clash fake-ip、远端 DNS、按域名分流场景下，目标域名应交给代理。
+
+Catcher 当前情况：
+
+- `ProxyConfig::transport_url()` 会把 `socks5://` 改成 `socks5h://`。
+- HTTP 和 WS 都用这个处理后的 URL。
+- 已补自动测试：
+  - `catcher-http/tests/proxy_dns_behavior_test.rs`
+  - `catcher-ws/tests/proxy_dns_behavior_test.rs`
+
+建议：
+
+- 保持现在的做法。
+- 不要再退回“使用系统 DNS 避开 Catcher DNS”的方案。正确做法是让代理路径不提前解析目标域名。
+
+### 4. no_proxy / bypass / escape
+
+常见形式：
+
+```text
+NO_PROXY=localhost,127.0.0.1,.company.internal,10.0.0.0/8
+```
+
+场景：
+
+- 内网域名直连。
+- localhost 不走代理。
+- Clash escape 让某些 App、域名或地址直连。
+- 企业代理排除私有网段。
+
+调研结论：
+
+- reqwest 有 `NoProxy`，支持域名、IPv4、IPv6、CIDR、`*`。
+- Android 的 `LinkProperties.getHttpProxy()` 返回的是推荐代理，不会强制应用必须用。
+- Clash 自己的 escape 规则不会自动进入 Catcher，外部集成必须把结果转成 `proxy` 或 `no_proxy`。
+
+Catcher 当前情况：
+
+- `ProxyConfig.no_proxy` 已有。
+- HTTP 和 WS 都把 `no_proxy` 传给 reqwest。
+- 已有自动测试确认 HTTP / WS 命中 `no_proxy` 时不连接代理。
+
+建议：
+
+- 保持 HTTP / WS 的 `no_proxy` 自动测试。
+- 文档明确：外部集成必须把平台 bypass / PAC / escape 结果转换成 Catcher 配置。
+
+### 5. PAC / WPAD
+
+常见形式：
+
+```text
+FindProxyForURL(url, host) {
+  if (dnsDomainIs(host, ".internal")) return "DIRECT";
+  return "PROXY proxy.company.com:8080; DIRECT";
+}
+```
+
+场景：
+
+- 企业电脑和企业手机。
+- Electron 桌面端。
+- Wi-Fi 自动代理配置。
+
+调研结论：
+
+- PAC 是按 URL 动态返回 `DIRECT`、`PROXY`、`SOCKS` 等结果。
+- Chromium / Electron 已经有成熟的代理解析能力。
+- 在 Electron 中，应该用 `session.resolveProxy(url)` 得到某个 URL 的结果。
+
+Catcher 当前情况：
+
+- Rust 内核没有 PAC 解析器。
+- `ProxyConfig` 是 client 级配置，不是每个请求动态解析。
+
+建议：
+
+- 不在 Catcher Rust 内核实现 PAC 解释器。
+- `klip-electron` 应用 Electron 的 `session.resolveProxy(url)` 解析目标 URL。
+- 对固定 base URL，可以解析一次后创建对应 Catcher client。
+- 如果同一个 Catcher client 要请求多个不同域名，且 PAC 对这些域名返回不同代理，就应拆成多个 client，或后续增加“按请求选择代理”的能力。
+
+### 6. VPN / TUN
+
+场景：
+
+- Clash / Stash / Shadowrocket / Surge 的 VPN 模式。
+- 企业 VPN。
+- Android `VpnService`。
+- iOS Network Extension Packet Tunnel。
+
+调研结论：
+
+- VPN/TUN 改的是系统路由和 DNS，不一定有 HTTP/SOCKS 端口。
+- 应用里的 socket 通常仍会被系统网络栈路由进 VPN。
+- 问题常出在库自己缓存了旧 DNS、旧连接池，或者绕过了系统代理发现。
+
+Catcher 当前情况：
+
+- HTTP 有 `network_changed()`：清 DNS、重建 reqwest client、重置熔断器。
+- WS 有 `network_changed()`：断开、重建 reqwest client、立即重连。
+- `network_path_id` 已暴露给配置，但 Rust 内核目前只保存，不用它自动判断变化。
+
+建议：
+
+- 外部集成必须监听 VPN、Wi-Fi、蜂窝、代理、DNS 变化。
+- 如果只是同一配置下网络变了，调用 `network_changed()`。
+- 如果代理 URL、DNS nameserver、TLS CA、bypass 规则变了，必须重建 Catcher client。
+- 可以增加诊断日志，打印 `network_path_id`、DNS mode、proxy scheme、是否命中 no_proxy。
+
+### 7. DNS：系统 DNS、Private DNS、fake-ip、自定义 nameserver
+
+场景：
+
+- Android Private DNS。
+- iOS VPN DNS。
+- Clash fake-ip / redir-host。
+- 企业 split DNS。
+- 内网域名。
+- Catcher 自定义 `nameservers` 和 `host_mapping`。
+
+调研结论：
+
+- Android 文档提示，自定义 DNS 可能绕过 Android 9+ 的系统 DNS 保护。
+- Android `LinkProperties` 能看到 DNS server、Private DNS、NAT64 prefix。
+- 代理路径下，目标域名应该交给代理解析。
+
+Catcher 当前情况：
+
+- `dns` 配置存在时，默认仍是 `mode = "catcher"`。
+- `dns.mode = "native"` 是显式退出 Catcher DNS。
+- `fallback_to_default_nameservers` 默认关闭。
+- 代理路径已经避免提前解析目标域名。
+
+建议：
+
+- 保持 Catcher DNS 默认能力，不把默认改回 native。
+- 外部集成如果检测到 Android strict Private DNS，又没有显式业务需求使用 Catcher DNS，应考虑传 `dns.mode = "native"` 或不传 `dns`。
+- 如果业务需要 Catcher DNS，就应明确传入 nameserver / host_mapping，并在网络变化时重建。
+- 补文档说明：host_mapping 到 IPv4 地址可能破坏 IPv6-only / NAT64 场景。
+
+### 8. TLS / 企业证书 / 调试证书
+
+场景：
+
+- Charles、Proxyman、mitmproxy 抓包。
+- 企业网关 HTTPS 检查。
+- 自签名内网证书。
+
+调研结论：
+
+- Android 官方支持 Network Security Configuration 配置自定义 CA、debug CA、用户证书。
+- iOS / macOS 也有系统证书信任链和 URLSession / Network.framework 的 TLS 配置能力。
+
+Catcher 当前情况：
+
+- HTTP 和 WS 都有 `TlsConfig`。
+- 支持 `reject_unauthorized`、自定义 CA、客户端证书等字段。
+- WS 的 `pin_sha256` 当前仍未实现。
+
+建议：
+
+- 外部集成必须把企业 CA 或调试 CA 转成 Catcher 可用的 `TlsConfig`。
+- 文档中明确：如果系统 URLSession 能访问，但 Catcher 不能访问，除了 proxy/DNS，还要检查 CA 是否传入 Rust 层。
+- 补 WS `pin_sha256` 的状态说明，避免误以为 HTTP/WS 完全一致。
+
+### 9. IPv6-only / NAT64
+
+场景：
+
+- iOS IPv6-only 审核环境。
+- 运营商 IPv6-only 或 IPv6 优先网络。
+- NAT64 / DNS64。
+
+调研结论：
+
+- Apple 明确要求 App 支持 IPv6-only。
+- 硬编码 IPv4、只走 IPv4 socket、把域名映射到 IPv4 literal 都可能失败。
+
+Catcher 当前情况：
+
+- reqwest / rustls 正常支持 IPv6。
+- `host_mapping` 可以写 IPv4 或 IPv6，但如果移动网络是 IPv6-only，映射到 IPv4 可能破坏 NAT64。
+
+建议：
+
+- 文档中要求移动端不要把公网域名长期 host_mapping 到 IPv4。
+- 增加 IPv6 / NAT64 手动验证项。
+- 自动测试可以补 IPv6 loopback，但它不能完全代表 NAT64。
+
+### 10. 环境变量代理
+
+常见形式：
+
+```bash
+HTTP_PROXY=http://127.0.0.1:7890
+HTTPS_PROXY=http://127.0.0.1:7890
+ALL_PROXY=socks5://127.0.0.1:7890
+NO_PROXY=localhost,127.0.0.1
+```
+
+场景：
+
+- Node.js 服务端。
+- CLI 工具。
+- 开发机本地代理。
+
+Catcher 当前情况：
+
+- 纯 TS 包有 `proxy: true` 读取环境变量的逻辑。
+- Rust / NAPI / Dart 层不自动读环境变量。
+
+建议：
+
+- 保持 Rust 内核不读环境变量，避免移动端行为不可控。
+- Node / Electron 接入层可以读取环境变量，并显式传 `ProxyConfig`。
+- 如果将来需要，可在 NAPI TS wrapper 增加“读取环境变量并转成 config”的辅助函数，不放进 Rust core。
+
+### 11. 登录型 Wi-Fi / captive portal
+
+场景：
+
+- 酒店、机场、公司访客 Wi-Fi。
+- DNS 可解析，但 HTTP/HTTPS 被重定向或阻断，直到用户登录。
+
+Catcher 当前情况：
+
+- 没有专门识别 captive portal。
+
+建议：
+
+- 不在 Catcher 内核做网页登录判断。
+- 错误分类和诊断日志要能区分 DNS、连接、TLS、HTTP 3xx/4xx。
+- 外部 App 自己决定是否打开系统网页登录页或提示用户。
+
+## Catcher 架构调整建议
+
+### 已经正确的方向
+
+1. **Catcher DNS 不能被取消。**
+   DNS 缓存、host mapping、自定义 nameserver 仍是 Catcher 的核心能力。
+
+2. **代理路径不能提前解析业务域名。**
+   `socks5://` 按 `socks5h://` 处理是正确方向。HTTP 和 WS 都已覆盖。
+
+3. **HTTP 和 WS 统一走 reqwest 配置。**
+   这样 proxy、TLS、DNS、连接池重建逻辑一致。
+
+4. **网络变化要打断旧连接。**
+   HTTP 重建 reqwest client；WS 断开并立即重连。
+
+### 应该补的代码和测试
+
+| 优先级 | 项目 | 原因 |
+|--------|------|------|
+| P0 | 诊断日志 | 客户现场最难判断卡在 DNS、代理连接、TLS 还是 WS 握手 |
+| P1 | 明确 `network_changed()` vs 重建 client | 配置变化时不能只调用 `network_changed()` |
+| P1 | Electron 接入文档 | `session.resolveProxy(url)` 结果要转换成 `ProxyConfig` 或直连 |
+| P1 | Android / iOS 接入文档 | 平台 DNS、代理、VPN、证书变化如何映射到 Catcher |
+| P2 | HTTPS proxy 测试 | 企业场景可能需要，但系统代理里不一定常见 |
+| P2 | IPv6 / NAT64 验证 | 移动端必须列入发版前真机验证 |
+| P2 | 代理认证扩展 | 目前只有 Basic；NTLM / Kerberos 等企业代理另行评估 |
+
+### 不应该现在做的事
+
+1. **不要在 Rust 内核实现 PAC 解释器。**
+   PAC 是平台和浏览器已有能力，Electron 和系统 API 更适合做。
+
+2. **不要让 Catcher 自动猜系统代理。**
+   移动端权限、系统差异、PAC、VPN、企业配置都太多。自动猜错比不猜更危险。
+
+3. **不要把 DNS 默认改成 native。**
+   这会削弱 Catcher 的价值。正确做法是：代理路径交给代理解析，非代理路径继续保留 Catcher DNS 能力。
+
+4. **不要把所有网络变化都当成同一种变化。**
+   网络切换、代理变化、DNS 变化、证书变化的处理不同。配置变了就重建 client。
+
+## 对外部集成的明确要求
+
+### echoo-flutter
+
+需要做：
+
+- iOS / Android 侧发现当前是否有 VPN。
+- Android 读取 `ConnectivityManager`、`LinkProperties`、默认 proxy、DNS server、Private DNS。
+- iOS 读取可用的系统代理信息；如果平台无法稳定读取，则由 App 配置层显式传入。
+- 代理、DNS、证书、网络路径变化后重建 HTTP / WS client。
+- 如果只是同配置网络切换，调用 `networkChanged()`。
+
+不能做：
+
+- 不能假设 Dart 原有 HTTP client 能用，Rust FFI 就自动继承同样代理。
+- 不能只给 HTTP 传 proxy，而 WS 不传。
+
+### klip-electron
+
+需要做：
+
+- 对每个 base URL 使用 `session.resolveProxy(url)`。
+- 解析结果为 `DIRECT` 时，不传 proxy。
+- 解析结果为 `PROXY host:port` 时，传 `http://host:port`。
+- 解析结果为 `HTTPS host:port` 时，传 `https://host:port` 并列入验证。
+- 解析结果为 `SOCKS` / `SOCKS5` 时，传 `socks5://host:port`，由 Catcher 内部转成远端 DNS。
+- 代理配置变化后关闭旧连接并重建 Catcher client。
+
+不能做：
+
+- 不要把 PAC 文件路径直接传给 Catcher。
+- 不要让一个 Catcher client 混跑多个 PAC 结果不同的域名。
+
+## 验证矩阵
+
+| 场景 | 自动测试 | 手动测试 |
+|------|----------|----------|
+| HTTP proxy | 已有本机 ignored 测试 | Clash HTTP proxy |
+| HTTP CONNECT | 已有自动测试 | HTTPS / WSS 过本地 HTTP proxy |
+| SOCKS5 远端 DNS | 已有自动测试 | Clash SOCKS5 |
+| no_proxy / bypass | 已有自动测试 | Clash escape / 企业 bypass |
+| PAC | 不在 Rust 内核测 | Electron `session.resolveProxy(url)` |
+| VPN/TUN | 部分通过 `network_changed()` 测试 | iOS / Android 真机 Clash VPN |
+| Android Private DNS | 无 | Android 真机 |
+| 企业 CA / 抓包证书 | 部分 TLS 单测 | Charles / Proxyman / mitmproxy |
+| IPv6 / NAT64 | 待补 IPv6 loopback | iOS IPv6-only / NAT64 |
+| captive portal | 不测 | 真实 Wi-Fi |
+
+## 下一步
+
+1. 增加安全诊断日志，不记录敏感 token，只记录网络路径、DNS 模式、proxy scheme、错误阶段。
+2. 把 echoo-flutter 和 klip-electron 的接入要求更新到各自 `docs/issues/`。
+3. 在真机上跑 Clash VPN / fake-ip / escape / HTTP proxy / SOCKS5 / Private DNS / IPv6 的验证矩阵。

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -63,6 +63,7 @@
 | # | Issue | 优先级 | 状态 | 文件 |
 |---|-------|:------:|:----:|------|
 | M-01 | Clash / VPN / 本地代理下请求失败 | 🔴 P0 | Catcher 已实现，待验证 | [026-mobile-proxy-vpn-clash.md](./026-mobile-proxy-vpn-clash.md) |
+| M-02 | 代理 / VPN / 本地网络兼容范围 | 🔴 P0 | 已调研，待补验证项 | [027-proxy-vpn-network-compatibility-research.md](./027-proxy-vpn-network-compatibility-research.md) |
 
 
 ## 间题之间的关联

--- a/docs/user-manual/api/dart.md
+++ b/docs/user-manual/api/dart.md
@@ -42,7 +42,7 @@ class CatcherHttpClient {
 | `connectTimeoutMs` | `int` | `10000` | 连接超时（ms） |
 | `responseTimeoutMs` | `int` | `30000` | 响应超时（ms） |
 | `pool` | `PoolConfig` | 默认配置 | 连接池配置 |
-| `dns` | `DnsConfig?` | — | DNS 缓存、旧缓存兜底、自定义解析 |
+| `dns` | `DnsConfig?` | — | DNS 缓存、旧缓存兜底、自定义解析；显式 `mode: 'native'` 时使用原生解析 |
 | `retry` | `RetryConfig?` | — | 重试配置 |
 | `circuitBreaker` | `CircuitBreakerConfig?` | — | 熔断器配置 |
 | `msgpack` | `bool` | `false` | 启用 HTTP body 自动 JSON ↔ msgpack |
@@ -51,6 +51,7 @@ class CatcherHttpClient {
 
 | 参数 | 类型 | 默认 | 说明 |
 |------|------|------|------|
+| `mode` | `String` | `'catcher'` | `'native'` 使用原生解析 |
 | `cacheSize` | `int` | `512` | DNS 缓存条目上限 |
 | `cacheTtlSecs` | `int` | `300` | 正常缓存有效时间（秒） |
 | `negativeTtlSecs` | `int` | `60` | 失败结果缓存时间（秒） |
@@ -159,7 +160,7 @@ class CatcherWsClient {
 | `heartbeat` | `HeartbeatConfig?` | — | 心跳 |
 | `heartbeat.intervalMs` | `int` | `30000` | 心跳间隔（ms） |
 | `heartbeat.adaptive` | `bool` | `true` | 自适应间隔 |
-| `dns` | `DnsConfig?` | — | DNS 缓存、旧缓存兜底、自定义解析 |
+| `dns` | `DnsConfig?` | — | DNS 缓存、旧缓存兜底、自定义解析；显式 `mode: 'native'` 时使用原生解析 |
 | `msgpack` | `bool` | `false` | 启用 WS 文本消息 JSON ↔ msgpack |
 
 ### WsEvent 类型

--- a/docs/user-manual/api/napi.md
+++ b/docs/user-manual/api/napi.md
@@ -88,6 +88,7 @@ const client = new HttpClient({
     half_open_max_requests: 5,
   },
   dns: {
+    mode: 'catcher',
     cache_size: 512,
     cache_ttl_secs: 300,
     negative_ttl_secs: 60,
@@ -124,6 +125,7 @@ const client = new HttpClient({
 | `circuit_breaker.half_open_max_requests` | `number` | `5` | HALF_OPEN 最大放行数 |
 | `tls` | `TlsConfig` | — | TLS 配置（14 字段） |
 | `dns` | `DnsConfig` | — | DNS 配置 |
+| `dns.mode` | `'catcher' \| 'native'` | `'catcher'` | `native` 使用协议库原生解析 |
 | `dns.cache_size` | `number` | `512` | DNS 缓存条目数上限 |
 | `dns.cache_ttl_secs` | `number` | `300` | DNS 缓存 TTL（秒） |
 | `dns.negative_ttl_secs` | `number` | `60` | 否定缓存 TTL（秒） |

--- a/docs/user-manual/api/rust-http.md
+++ b/docs/user-manual/api/rust-http.md
@@ -143,6 +143,7 @@ pub struct TlsConfig {
 
 ```rust
 pub struct DnsConfig {
+    pub mode: DnsMode,                       // 默认 Native；Catcher 才启用缓存和 host_mapping
     pub cache_ttl_secs: u32,                 // 默认 300
     pub nameservers: Vec<String>,
     pub host_mapping: HashMap<String, String>,
@@ -153,7 +154,7 @@ pub struct DnsConfig {
 
 ```rust
 pub struct ProxyConfig {
-    pub url: String,                         // "http://host:port" | "socks5://host:port"
+    pub url: String,                         // http / https / socks5 / socks5h
     pub auth: Option<ProxyAuth>,
     pub no_proxy: Vec<String>,
 }
@@ -163,6 +164,9 @@ pub struct ProxyAuth {
     pub password: String,
 }
 ```
+
+`socks5://` 会按 `socks5h://` 处理，让代理解析目标域名，避免 Clash
+fake-ip、VPN 分流等场景下提前本地解析。
 
 ### RedirectConfig
 

--- a/docs/user-manual/nodejs.md
+++ b/docs/user-manual/nodejs.md
@@ -32,7 +32,6 @@ const client = new HttpClient({
   response_timeout_ms: 30000,
   retry: { max_attempts: 3, backoff: 'Fixed' },
   circuit_breaker: { failure_threshold: 5, reset_timeout_ms: 30000 },
-  dns: { cache_ttl_secs: 300, stale_on_error: true },
   msgpack: true,
 })
 
@@ -206,10 +205,14 @@ contextBridge.exposeInMainWorld('api', {
 
 ## 四、DNS 缓存
 
-NAPI 版内置 StaleAwareDnsResolver，默认启用。无需额外配置即可获得 DNS 缓存。
+配置 `dns` 后默认接入 Catcher DNS，启用 DNS 缓存、旧缓存兜底、
+自定义 nameserver 和 host mapping。代理场景下，目标域名交给代理解析，
+Catcher DNS 不会提前把目标域名改成 IP。只有显式配置
+`dns.mode = 'native'` 时，才使用底层协议库原生解析。
 
 | 配置 | 说明 | 默认值 |
 |------|------|--------|
+| `dns.mode` | `catcher` 启用 Catcher DNS；`native` 原生解析 | `catcher` |
 | `dns.cache_ttl_secs` | 缓存有效期 | 300 |
 | `dns.stale_ttl_secs` | 过期后仍可用的宽限期 | 3600 |
 | `dns.stale_on_error` | DNS 失败时用旧缓存兜底 | true |

--- a/docs/user-manual/resilience.md
+++ b/docs/user-manual/resilience.md
@@ -406,6 +406,7 @@ NAPI 版内置 `StaleAwareDnsResolver`，实现 RFC 8767 启发的 stale-while-r
 
 | 参数 | 默认 | 说明 |
 |------|------|------|
+| `mode` | `catcher` | `catcher` 启用 Catcher DNS；`native` 使用协议库原生解析 |
 | `cache_size` | 512 | 缓存条目数上限 |
 | `cache_ttl_secs` | 300 | 正常缓存有效期（秒） |
 | `negative_ttl_secs` | 60 | 否定缓存 TTL（秒） |
@@ -783,9 +784,10 @@ catcher_ws_network_changed(ws_handle);      // FfiResult
   避免每次通断都触发重连风暴。
 - **不调用也能恢复**：`networkChanged()` 是优化而非必需 — 不调用时
   心跳超时/keepalive 探针仍会兜底自愈，只是慢 10-30 秒。
-- **DNS 服务器不会重读**：解析器的 nameserver 列表在创建时确定
-  （系统配置仅读取一次）。`networkChanged()` 清空解析缓存，但若新网络
-  推送了不同的系统 DNS 服务器，需要自定义 `dns.nameservers` 或重建客户端。
+- **DNS 会按模式处理**：配置 `dns` 后默认走 Catcher DNS。
+  `networkChanged()` 会清空缓存并重建 Catcher DNS resolver，重新读取系统 DNS；
+  如果重建失败，旧 resolver 会继续保留并发出错误事件。显式
+  `dns.mode = "native"` 时，才走协议库原生解析。
 - **发送超时**（WS）：半开连接上的发送会阻塞到 TCP 重传超时（分钟级）。
   `send_timeout_ms`（默认 10s，0 = 不限制）保证单帧发送超时后立即判定
   断线进入重连，事件循环不会被卡住。

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "bytes",
  "catcher-core",
  "catcher-dns",
+ "catcher-test-support",
  "http",
  "napi",
  "napi-derive",
@@ -422,6 +423,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "catcher-test-support"
+version = "0.3.12"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "catcher-uniffi"
 version = "0.3.12"
 dependencies = [
@@ -443,6 +451,7 @@ dependencies = [
  "base64",
  "catcher-core",
  "catcher-dns",
+ "catcher-test-support",
  "flate2",
  "futures-util",
  "http",

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "catcher-core",
     "catcher-dns",
+    "catcher-test-support",
     "catcher-http",
     "catcher-ws",
     "catcher-ffi",

--- a/packages/catcher-core-ts/src/types.ts
+++ b/packages/catcher-core-ts/src/types.ts
@@ -20,7 +20,7 @@ export interface SharedAgentOptions {
 // === Proxy ===
 
 export interface ProxyConfig {
-  /** "http://host:port" | "https://host:port" | "socks5://host:port" | "socks5h://host:port" */
+  /** "http://host:port" | "https://host:port" | "socks5://host:port" | "socks5h://host:port". Catcher treats socks5 as remote DNS. */
   url: string
   auth?: { username: string; password: string }
   noProxy?: string[]
@@ -29,7 +29,7 @@ export interface ProxyConfig {
 // === DNS ===
 
 export interface DnsConfig {
-  /** DNS mode. Not setting dns lets the transport use its native resolver. */
+  /** DNS mode. Default catcher. Use native only when you want the transport resolver. */
   mode?: 'catcher' | 'native'
   /** Custom DNS nameservers (e.g. ["8.8.8.8"]) */
   nameservers?: string[]

--- a/packages/catcher-core/src/error.rs
+++ b/packages/catcher-core/src/error.rs
@@ -238,12 +238,24 @@ mod tests {
             CatcherError::ConnectionTimeout(1000),
             CatcherError::RequestTimeout(5000),
             CatcherError::TlsError("test".into()),
-            CatcherError::DnsError { host: "h".into(), reason: "r".into() },
-            CatcherError::HttpError { status: 500, body: "b".into() },
+            CatcherError::DnsError {
+                host: "h".into(),
+                reason: "r".into(),
+            },
+            CatcherError::HttpError {
+                status: 500,
+                body: "b".into(),
+            },
             CatcherError::WsHandshakeTimeout(3000),
-            CatcherError::WsDisconnected { code: 1000, reason: "normal".into() },
+            CatcherError::WsDisconnected {
+                code: 1000,
+                reason: "normal".into(),
+            },
             CatcherError::WsAllEndpointsFailed { count: 1 },
-            CatcherError::RetryExhausted { attempts: 3, last_error: "e".into() },
+            CatcherError::RetryExhausted {
+                attempts: 3,
+                last_error: "e".into(),
+            },
             CatcherError::CircuitBreakerOpen,
             CatcherError::QueueTimeout(1000),
             CatcherError::EncodeError("e".into()),
@@ -254,7 +266,11 @@ mod tests {
         ];
         for err in &errors {
             let s = err.to_string();
-            assert!(!s.is_empty(), "Display should produce non-empty string for {:?}", err);
+            assert!(
+                !s.is_empty(),
+                "Display should produce non-empty string for {:?}",
+                err
+            );
         }
     }
 }

--- a/packages/catcher-core/src/ffi_types.rs
+++ b/packages/catcher-core/src/ffi_types.rs
@@ -123,10 +123,7 @@ pub extern "C" fn catcher_free_result(result: FfiResult) {
 /// - `event_data` must be a valid pointer returned by `CString::into_raw()`, or null.
 /// - Both pointers must not have been freed already (no double-free).
 #[no_mangle]
-pub unsafe extern "C" fn catcher_free_event_data(
-    event_type: *mut c_char,
-    event_data: *mut u8,
-) {
+pub unsafe extern "C" fn catcher_free_event_data(event_type: *mut c_char, event_data: *mut u8) {
     if !event_type.is_null() {
         let _ = std::ffi::CString::from_raw(event_type);
     }

--- a/packages/catcher-core/src/handle_registry.rs
+++ b/packages/catcher-core/src/handle_registry.rs
@@ -4,10 +4,10 @@
 //! 使用 `RwLock` 替代 `Mutex`，允许多线程并发读取 handle。
 
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::RwLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::RwLock;
 
 /// 泛型 FFI handle 注册表。
 ///

--- a/packages/catcher-core/src/types/network.rs
+++ b/packages/catcher-core/src/types/network.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 use super::default_true;
 
@@ -94,4 +95,58 @@ pub struct ProxyConfig {
     pub auth: Option<ProxyAuth>,
     #[serde(alias = "noProxy", default)]
     pub no_proxy: Vec<String>,
+}
+
+impl ProxyConfig {
+    /// 返回协议库实际使用的代理地址。
+    ///
+    /// `socks5://` 会让 reqwest 在本地先解析目标域名。Clash fake-ip、VPN
+    /// 分流和远端 DNS 场景下，这会把域名提前变成 IP，代理无法再按域名处理。
+    /// 因此 Catcher 将 `socks5://` 统一按 `socks5h://` 处理，让代理解析目标域名。
+    pub fn transport_url(&self) -> Cow<'_, str> {
+        let Some((scheme, rest)) = self.url.split_once("://") else {
+            return Cow::Borrowed(self.url.as_str());
+        };
+        if scheme.eq_ignore_ascii_case("socks5") {
+            Cow::Owned(format!("socks5h://{rest}"))
+        } else {
+            Cow::Borrowed(self.url.as_str())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProxyConfig;
+
+    fn proxy_url(url: &str) -> String {
+        ProxyConfig {
+            url: url.to_string(),
+            auth: None,
+            no_proxy: Vec::new(),
+        }
+        .transport_url()
+        .into_owned()
+    }
+
+    #[test]
+    fn socks5_proxy_uses_remote_dns() {
+        assert_eq!(
+            proxy_url("socks5://127.0.0.1:7890"),
+            "socks5h://127.0.0.1:7890"
+        );
+        assert_eq!(
+            proxy_url("SOCKS5://127.0.0.1:7890"),
+            "socks5h://127.0.0.1:7890"
+        );
+    }
+
+    #[test]
+    fn other_proxy_schemes_are_unchanged() {
+        assert_eq!(
+            proxy_url("socks5h://127.0.0.1:7890"),
+            "socks5h://127.0.0.1:7890"
+        );
+        assert_eq!(proxy_url("http://127.0.0.1:7890"), "http://127.0.0.1:7890");
+    }
 }

--- a/packages/catcher-dns/README.md
+++ b/packages/catcher-dns/README.md
@@ -23,9 +23,10 @@ catcher-dns = "0.3.11"
 ```
 
 ```rust
-use catcher_dns::{build_stale_aware_resolver, DnsConfig};
+use catcher_dns::{build_stale_aware_resolver, DnsConfig, DnsMode};
 
 let config = DnsConfig {
+    mode: DnsMode::Catcher,
     cache_size: 512,
     cache_ttl_secs: 300,
     negative_ttl_secs: 60,

--- a/packages/catcher-dns/src/lib.rs
+++ b/packages/catcher-dns/src/lib.rs
@@ -603,10 +603,24 @@ mod tests {
     }
 
     #[test]
+    fn dns_config_can_use_catcher_mode() {
+        let config: DnsConfig = serde_json::from_str(r#"{"mode":"catcher"}"#).unwrap();
+        assert_eq!(config.mode, DnsMode::Catcher);
+        assert!(config.use_catcher_resolver());
+    }
+
+    #[test]
     fn dns_config_can_use_native_mode() {
         let config: DnsConfig = serde_json::from_str(r#"{"mode":"native"}"#).unwrap();
         assert_eq!(config.mode, DnsMode::Native);
         assert!(!config.use_catcher_resolver());
+    }
+
+    #[test]
+    fn partial_dns_config_keeps_catcher_mode() {
+        let config: DnsConfig = serde_json::from_str(r#"{"cache_ttl_secs":300}"#).unwrap();
+        assert_eq!(config.mode, DnsMode::Catcher);
+        assert!(config.use_catcher_resolver());
     }
 
     #[test]
@@ -782,6 +796,7 @@ mod tests {
     #[test]
     fn resolver_builds_with_nameservers() {
         let config = DnsConfig {
+            mode: DnsMode::Catcher,
             nameservers: vec!["8.8.8.8:53".to_string()],
             ..Default::default()
         };
@@ -793,6 +808,7 @@ mod tests {
     #[test]
     fn resolver_rejects_invalid_nameserver() {
         let config = DnsConfig {
+            mode: DnsMode::Catcher,
             nameservers: vec!["not-an-address".to_string()],
             ..Default::default()
         };

--- a/packages/catcher-ffi/tests/codec_quality_test.rs
+++ b/packages/catcher-ffi/tests/codec_quality_test.rs
@@ -6,7 +6,9 @@
 use std::ffi::{c_char, c_void, CStr, CString};
 
 unsafe fn read_c_string(ptr: *mut c_char) -> String {
-    if ptr.is_null() { return String::new(); }
+    if ptr.is_null() {
+        return String::new();
+    }
     let s = CStr::from_ptr(ptr).to_string_lossy().to_string();
     catcher_ffi::catcher_free_data(ptr as *mut c_void, s.len() + 1);
     s
@@ -25,7 +27,8 @@ fn c01_pack_roundtrip() {
     assert!(packed.data_len > 0);
 
     // Unpack back
-    let unpacked = unsafe { catcher_ffi::catcher_unpack(packed.data as *const u8, packed.data_len) };
+    let unpacked =
+        unsafe { catcher_ffi::catcher_unpack(packed.data as *const u8, packed.data_len) };
     assert_eq!(unpacked.error_code, 0, "unpack should succeed");
 
     // Free

--- a/packages/catcher-ffi/tests/http_test.rs
+++ b/packages/catcher-ffi/tests/http_test.rs
@@ -56,7 +56,9 @@ async fn h01_create_and_destroy_client() {
     let handle = unsafe { http::catcher_http_client_create(c_config.as_ptr()) };
     assert!(!handle.is_null(), "client creation should succeed");
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 /// destroy 之后用旧句柄调用任何 API 必须安全失败（句柄是注册表 id
@@ -69,14 +71,16 @@ async fn h16_stale_handle_after_destroy_is_safe() {
 
     let handle = unsafe { http::catcher_http_client_create(c_config.as_ptr()) };
     assert!(!handle.is_null());
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 
     // 全部 API 用已销毁的句柄调用：不崩溃、返回失败码
     unsafe {
         assert_eq!(http::catcher_http_network_changed(handle), 1);
         assert_eq!(http::catcher_http_cancel_request(handle, 1), -1);
         http::catcher_http_client_cancel_all(handle); // 应为 no-op
-        // 重复 destroy 安全
+                                                      // 重复 destroy 安全
         http::catcher_http_client_destroy(handle);
     }
 }
@@ -94,8 +98,8 @@ async fn h17_garbage_handle_is_safe() {
 
 #[tokio::test]
 async fn h02_get_request_with_wiremock() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -136,13 +140,15 @@ async fn h02_get_request_with_wiremock() {
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or_default();
     assert_eq!(parsed["status"], 200);
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
 async fn h03_execute_with_headers() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
-    use wiremock::matchers::{method, header};
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -189,7 +195,9 @@ async fn h03_execute_with_headers() {
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or_default();
     assert_eq!(parsed["status"], 200);
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
@@ -205,7 +213,9 @@ async fn h04_circuit_breaker_state() {
     // No CB configured → "disabled"
     assert_eq!(parsed["state"], "disabled");
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
@@ -221,7 +231,9 @@ async fn h05_metrics_returns_data() {
     // Metrics should exist even with zero values
     assert!(parsed.get("http_requests").is_some());
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
@@ -232,12 +244,16 @@ async fn h06_cancel_all_does_not_panic() {
     assert!(!handle.is_null());
 
     // Cancel should not panic even with no in-flight requests
-    unsafe { http::catcher_http_client_cancel_all(handle); }
+    unsafe {
+        http::catcher_http_client_cancel_all(handle);
+    }
 
     // New request after cancel should work
     let _metrics_ptr = unsafe { http::catcher_http_metrics(handle) };
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
@@ -257,7 +273,9 @@ async fn h07_adaptive_timeout_config() {
         http::catcher_http_adaptive_timeout_config(handle, 0, 0, 0, 0, 0);
     }
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 // ── N-03: Per-request cancel tests ──
@@ -270,11 +288,15 @@ extern "C" fn capture_to_result(
 ) {
     let bytes = unsafe { std::slice::from_raw_parts(event_data, event_data_len) };
     let json = String::from_utf8_lossy(bytes).to_string();
-    unsafe { catcher_core::ffi_types::catcher_free_event_data(_event_type as *mut c_char, event_data as *mut u8); }
+    unsafe {
+        catcher_core::ffi_types::catcher_free_event_data(
+            _event_type as *mut c_char,
+            event_data as *mut u8,
+        );
+    }
     let result: &Mutex<Option<String>> = unsafe { &*(user_data as *const Mutex<Option<String>>) };
     *result.lock().unwrap() = Some(json);
 }
-
 
 fn make_result_cell() -> (Arc<Mutex<Option<String>>>, *mut c_void) {
     let cell = Arc::new(Mutex::new(None::<String>));
@@ -284,13 +306,14 @@ fn make_result_cell() -> (Arc<Mutex<Option<String>>>, *mut c_void) {
 
 #[tokio::test]
 async fn h08_execute_with_id_returns_request_id() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
-        .mount(&server).await;
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "connect_timeout_ms": 5000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -300,32 +323,46 @@ async fn h08_execute_with_id_returns_request_id() {
     let (_cell, user_data) = make_result_cell();
     let request_id = unsafe {
         http::catcher_http_execute_with_id(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""),
-            std::ptr::null(), 0,
-            capture_to_result, user_data,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            user_data,
         )
     };
     assert!(request_id > 0);
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let result_ref: &Mutex<Option<String>> = unsafe { &*(user_data as *const Mutex<Option<String>>) };
-    let json = result_ref.lock().unwrap().clone().expect("callback should have been invoked");
+    let result_ref: &Mutex<Option<String>> =
+        unsafe { &*(user_data as *const Mutex<Option<String>>) };
+    let json = result_ref
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("callback should have been invoked");
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or_default();
     assert_eq!(parsed["request_id"], request_id);
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
 async fn h09_cancel_request_by_id() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(30)))
-        .mount(&server).await;
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "connect_timeout_ms": 2000, "response_timeout_ms": 5000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -335,24 +372,43 @@ async fn h09_cancel_request_by_id() {
     let (_cell, user_data) = make_result_cell();
     let request_id = unsafe {
         http::catcher_http_execute_with_id(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""),
-            std::ptr::null(), 0,
-            capture_to_result, user_data,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            user_data,
         )
     };
     assert!(request_id > 0);
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    assert_eq!(unsafe { http::catcher_http_cancel_request(handle, request_id) }, 0);
+    assert_eq!(
+        unsafe { http::catcher_http_cancel_request(handle, request_id) },
+        0
+    );
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let result_ref: &Mutex<Option<String>> = unsafe { &*(user_data as *const Mutex<Option<String>>) };
-    let json = result_ref.lock().unwrap().clone().expect("callback should have been invoked");
+    let result_ref: &Mutex<Option<String>> =
+        unsafe { &*(user_data as *const Mutex<Option<String>>) };
+    let json = result_ref
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("callback should have been invoked");
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or_default();
-    assert!(parsed.get("type").is_some() || parsed.get("error").is_some(), "expected error or cancelled, got: {json}");
+    assert!(
+        parsed.get("type").is_some() || parsed.get("error").is_some(),
+        "expected error or cancelled, got: {json}"
+    );
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
@@ -361,19 +417,25 @@ async fn h10_cancel_request_nonexistent() {
     let c_config = CString::new(config).unwrap();
     let handle = unsafe { http::catcher_http_client_create(c_config.as_ptr()) };
     assert!(!handle.is_null());
-    assert_eq!(unsafe { http::catcher_http_cancel_request(handle, 99999) }, -1);
-    unsafe { http::catcher_http_client_destroy(handle); }
+    assert_eq!(
+        unsafe { http::catcher_http_cancel_request(handle, 99999) },
+        -1
+    );
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
 async fn h11_cancel_all_with_per_request() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(5)))
-        .mount(&server).await;
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "connect_timeout_ms": 10000, "response_timeout_ms": 10000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -383,51 +445,75 @@ async fn h11_cancel_all_with_per_request() {
     let (cell1, ud1) = make_result_cell();
     let id1 = unsafe {
         http::catcher_http_execute_with_id(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""), std::ptr::null(), 0,
-            capture_to_result, ud1,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            ud1,
         )
     };
     assert!(id1 > 0);
 
-    unsafe { http::catcher_http_client_cancel_all(handle); }
+    unsafe {
+        http::catcher_http_client_cancel_all(handle);
+    }
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
     let (cell2, ud2) = make_result_cell();
     let new_id = unsafe {
         http::catcher_http_execute_with_id(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""), std::ptr::null(), 0,
-            capture_to_result, ud2,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            ud2,
         )
     };
     assert!(new_id > 0);
     assert_ne!(new_id, id1);
 
-    unsafe { http::catcher_http_client_cancel_all(handle); }
+    unsafe {
+        http::catcher_http_client_cancel_all(handle);
+    }
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     drop(cell1.lock().unwrap());
     drop(cell2.lock().unwrap());
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
 async fn h12_cancel_request_null_handle() {
-    assert_eq!(unsafe { http::catcher_http_cancel_request(std::ptr::null_mut(), 1) }, -1);
+    assert_eq!(
+        unsafe { http::catcher_http_cancel_request(std::ptr::null_mut(), 1) },
+        -1
+    );
 }
 
 // N-02: Streaming download tests
 
 #[tokio::test]
 async fn h13_execute_stream_headers_and_chunks() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_body_string("hello world"))
-        .mount(&server).await;
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "connect_timeout_ms": 5000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -437,30 +523,47 @@ async fn h13_execute_stream_headers_and_chunks() {
     let (_cell, user_data) = make_result_cell();
     let rid = unsafe {
         http::catcher_http_execute_stream(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""),
-            std::ptr::null(), 0,
-            capture_to_result, user_data,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            user_data,
         )
     };
     assert!(rid > 0);
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let result_ref: &Mutex<Option<String>> = unsafe { &*(user_data as *const Mutex<Option<String>>) };
-    let json = result_ref.lock().unwrap().clone().expect("callback should have been invoked");
-    assert!(json.contains(&format!("{rid}")), "expected request_id in callback, got: {json}");
+    let result_ref: &Mutex<Option<String>> =
+        unsafe { &*(user_data as *const Mutex<Option<String>>) };
+    let json = result_ref
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("callback should have been invoked");
+    assert!(
+        json.contains(&format!("{rid}")),
+        "expected request_id in callback, got: {json}"
+    );
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
 async fn h14_execute_stream_returns_request_id() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
-        .mount(&server).await;
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "connect_timeout_ms": 5000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -470,20 +573,33 @@ async fn h14_execute_stream_returns_request_id() {
     let (_cell, user_data) = make_result_cell();
     let rid = unsafe {
         http::catcher_http_execute_stream(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""),
-            std::ptr::null(), 0,
-            capture_to_result, user_data,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            user_data,
         )
     };
     assert!(rid > 0);
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
     // request_id should appear in the callback data
-    let result_ref: &Mutex<Option<String>> = unsafe { &*(user_data as *const Mutex<Option<String>>) };
-    let json = result_ref.lock().unwrap().clone().expect("callback should have been invoked");
+    let result_ref: &Mutex<Option<String>> =
+        unsafe { &*(user_data as *const Mutex<Option<String>>) };
+    let json = result_ref
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("callback should have been invoked");
     assert!(json.contains(&format!("{rid}")));
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 // ── N-02/N-03 supplementary FFI tests ──
@@ -498,12 +614,20 @@ extern "C" fn capture_stream_events(
     let et = if event_type.is_null() {
         String::new()
     } else {
-        unsafe { CStr::from_ptr(event_type) }.to_string_lossy().to_string()
+        unsafe { CStr::from_ptr(event_type) }
+            .to_string_lossy()
+            .to_string()
     };
     let bytes = unsafe { std::slice::from_raw_parts(event_data, event_data_len) };
     let data = String::from_utf8_lossy(bytes).to_string();
-    unsafe { catcher_core::ffi_types::catcher_free_event_data(event_type as *mut c_char, event_data as *mut u8); }
-    let events: &Mutex<Vec<(String, String)>> = unsafe { &*(user_data as *const Mutex<Vec<(String, String)>>) };
+    unsafe {
+        catcher_core::ffi_types::catcher_free_event_data(
+            event_type as *mut c_char,
+            event_data as *mut u8,
+        );
+    }
+    let events: &Mutex<Vec<(String, String)>> =
+        unsafe { &*(user_data as *const Mutex<Vec<(String, String)>>) };
     events.lock().unwrap().push((et, data));
 }
 
@@ -516,15 +640,18 @@ fn make_events_cell() -> (Arc<Mutex<Vec<(String, String)>>>, *mut c_void) {
 
 #[tokio::test]
 async fn h15_execute_stream_cancel() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .respond_with(ResponseTemplate::new(200)
-            .set_body_string("x".repeat(65536))
-            .set_delay(std::time::Duration::from_secs(30)))
-        .mount(&server).await;
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("x".repeat(65536))
+                .set_delay(std::time::Duration::from_secs(30)),
+        )
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "response_timeout_ms": 60000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -534,10 +661,16 @@ async fn h15_execute_stream_cancel() {
     let (events, user_data) = make_events_cell();
     let _rid = unsafe {
         http::catcher_http_execute_stream(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""),
-            std::ptr::null(), 0,
-            capture_stream_events, user_data,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_stream_events,
+            user_data,
         )
     };
 
@@ -552,18 +685,21 @@ async fn h15_execute_stream_cancel() {
     let has_error = evts.iter().any(|(et, _)| et == "stream_error");
     assert!(has_error, "should have a stream_error event after cancel");
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
 async fn h18b_execute_callback_receives_response_with_request_id() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
-        .mount(&server).await;
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "connect_timeout_ms": 5000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -573,17 +709,28 @@ async fn h18b_execute_callback_receives_response_with_request_id() {
     let (_cell, user_data) = make_result_cell();
     let request_id = unsafe {
         http::catcher_http_execute_with_id(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""),
-            std::ptr::null(), 0,
-            capture_to_result, user_data,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            user_data,
         )
     };
     assert!(request_id > 0);
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let result_ref: &Mutex<Option<String>> = unsafe { &*(user_data as *const Mutex<Option<String>>) };
-    let json = result_ref.lock().unwrap().clone().expect("callback should have been invoked");
+    let result_ref: &Mutex<Option<String>> =
+        unsafe { &*(user_data as *const Mutex<Option<String>>) };
+    let json = result_ref
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("callback should have been invoked");
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or_default();
     // Verify response fields
     assert_eq!(parsed["status"], 200);
@@ -591,18 +738,21 @@ async fn h18b_execute_callback_receives_response_with_request_id() {
     assert_eq!(parsed["request_id"], request_id);
     assert!(parsed.get("elapsed_ms").is_some());
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }
 
 #[tokio::test]
 async fn h09b_cancel_request_returns_cancelled_json() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(30)))
-        .mount(&server).await;
+        .mount(&server)
+        .await;
 
     let config = serde_json::json!({"base_url": server.uri(), "response_timeout_ms": 60000});
     let c_config = CString::new(config.to_string()).unwrap();
@@ -612,24 +762,40 @@ async fn h09b_cancel_request_returns_cancelled_json() {
     let (_cell, user_data) = make_result_cell();
     let request_id = unsafe {
         http::catcher_http_execute_with_id(
-            handle, ffi_string("GET"), ffi_string("/test"),
-            std::ptr::null(), 0, ffi_string(""),
-            std::ptr::null(), 0,
-            capture_to_result, user_data,
+            handle,
+            ffi_string("GET"),
+            ffi_string("/test"),
+            std::ptr::null(),
+            0,
+            ffi_string(""),
+            std::ptr::null(),
+            0,
+            capture_to_result,
+            user_data,
         )
     };
     assert!(request_id > 0);
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    assert_eq!(unsafe { http::catcher_http_cancel_request(handle, request_id) }, 0);
+    assert_eq!(
+        unsafe { http::catcher_http_cancel_request(handle, request_id) },
+        0
+    );
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-    let result_ref: &Mutex<Option<String>> = unsafe { &*(user_data as *const Mutex<Option<String>>) };
-    let json = result_ref.lock().unwrap().clone().expect("callback should have been invoked");
+    let result_ref: &Mutex<Option<String>> =
+        unsafe { &*(user_data as *const Mutex<Option<String>>) };
+    let json = result_ref
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("callback should have been invoked");
     let parsed: serde_json::Value = serde_json::from_str(&json).unwrap_or_default();
     // N-03: cancelled callback should have type="cancelled" and request_id
     assert_eq!(parsed["type"], "cancelled");
     assert_eq!(parsed["request_id"], request_id);
 
-    unsafe { http::catcher_http_client_destroy(handle); }
+    unsafe {
+        http::catcher_http_client_destroy(handle);
+    }
 }

--- a/packages/catcher-ffi/tests/quality_test.rs
+++ b/packages/catcher-ffi/tests/quality_test.rs
@@ -16,7 +16,10 @@ struct CallbackState {
 }
 
 fn make_callback_state() -> (Arc<Mutex<CallbackState>>, *mut c_void) {
-    let state = Arc::new(Mutex::new(CallbackState { count: 0, last_event: None }));
+    let state = Arc::new(Mutex::new(CallbackState {
+        count: 0,
+        last_event: None,
+    }));
     let ptr = Arc::as_ptr(&state) as *mut c_void;
     (state, ptr)
 }
@@ -27,10 +30,17 @@ extern "C" fn capture_quality_callback(
     event_data_len: usize,
     user_data: *mut c_void,
 ) {
-    if user_data.is_null() { return; }
+    if user_data.is_null() {
+        return;
+    }
     let bytes = unsafe { std::slice::from_raw_parts(event_data, event_data_len) };
     let json = String::from_utf8_lossy(bytes).to_string();
-    unsafe { catcher_core::ffi_types::catcher_free_event_data(_event_type as *mut c_char, event_data as *mut u8); }
+    unsafe {
+        catcher_core::ffi_types::catcher_free_event_data(
+            _event_type as *mut c_char,
+            event_data as *mut u8,
+        );
+    }
     let state: &Mutex<CallbackState> = unsafe { &*(user_data as *const Mutex<CallbackState>) };
     let mut s = state.lock().unwrap();
     s.count += 1;
@@ -62,7 +72,10 @@ async fn q02_subscribe_receives_callback() {
     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
 
     let count = state.lock().unwrap().count;
-    assert!(count >= 1, "should receive at least 1 callback, got {count}");
+    assert!(
+        count >= 1,
+        "should receive at least 1 callback, got {count}"
+    );
 
     let event = state.lock().unwrap().last_event.clone();
     assert!(event.is_some(), "should have captured an event");
@@ -90,14 +103,20 @@ async fn q03_subscribe_unsubscribe() {
 
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     let count_before = state.lock().unwrap().count;
-    assert!(count_before >= 1, "should have callbacks before unsubscribe");
+    assert!(
+        count_before >= 1,
+        "should have callbacks before unsubscribe"
+    );
 
     unsafe { quality::catcher_quality_unsubscribe(sub_handle) };
 
     let count_at_unsub = state.lock().unwrap().count;
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     let count_after = state.lock().unwrap().count;
-    assert_eq!(count_after, count_at_unsub, "should have no new callbacks after unsubscribe");
+    assert_eq!(
+        count_after, count_at_unsub,
+        "should have no new callbacks after unsubscribe"
+    );
 }
 
 /// q04: Subscribe to invalid host doesn't crash
@@ -155,7 +174,10 @@ async fn q05_subscribe_multiple() {
     let count1 = state1.lock().unwrap().count;
     let count2 = state2.lock().unwrap().count;
     // sub2 should still be receiving callbacks (or at least not panicked)
-    assert!(count2 >= count1, "sub2 should have at least as many callbacks as sub1");
+    assert!(
+        count2 >= count1,
+        "sub2 should have at least as many callbacks as sub1"
+    );
 
     unsafe { quality::catcher_quality_unsubscribe(sub2) };
 }

--- a/packages/catcher-ffi/tests/sse_test.rs
+++ b/packages/catcher-ffi/tests/sse_test.rs
@@ -7,8 +7,8 @@ use std::ffi::{c_char, c_void, CStr, CString};
 use std::sync::Mutex;
 
 use catcher_core::ffi_types::FfiString;
-use catcher_http::ffi::sse_ffi as sse;
 use catcher_http::ffi::http_ffi as http;
+use catcher_http::ffi::sse_ffi as sse;
 
 static LAST_SSE_EVENT: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
@@ -20,7 +20,9 @@ fn ffi_string(s: &str) -> FfiString {
 }
 
 unsafe fn read_c_string(ptr: *mut c_char) -> String {
-    if ptr.is_null() { return String::new(); }
+    if ptr.is_null() {
+        return String::new();
+    }
     let s = CStr::from_ptr(ptr).to_string_lossy().to_string();
     catcher_ffi::catcher_free_data(ptr as *mut c_void, s.len() + 1);
     s
@@ -45,8 +47,8 @@ extern "C" fn sse_callback(
 
 #[tokio::test]
 async fn s01_sse_stream_basic() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let server = MockServer::start().await;
     // Return a simple SSE stream response
@@ -91,19 +93,25 @@ async fn s01_sse_stream_basic() {
     let events = LAST_SSE_EVENT.lock().unwrap().clone();
     assert!(!events.is_empty(), "should have received SSE events");
     // First event should be "open", followed by data events, ending with "close"
-    let types: Vec<String> = events.iter()
+    let types: Vec<String> = events
+        .iter()
         .filter_map(|e| serde_json::from_str::<serde_json::Value>(e).ok())
         .filter_map(|v| v["type"].as_str().map(|s| s.to_string()))
         .collect();
-    assert!(types.contains(&"data".to_string()), "should contain data events");
+    assert!(
+        types.contains(&"data".to_string()),
+        "should contain data events"
+    );
 
-    unsafe { http::catcher_http_client_destroy(http_handle); }
+    unsafe {
+        http::catcher_http_client_destroy(http_handle);
+    }
 }
 
 #[test]
 fn s02_sse_connect_and_ready_state() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // Use a temporary runtime for async mock setup. We keep rt alive so the
     // mock server stays running, but after block_on returns the thread is no
@@ -131,9 +139,8 @@ fn s02_sse_connect_and_ready_state() {
 
     LAST_SSE_EVENT.lock().unwrap().clear();
 
-    let sse_handle = unsafe {
-        sse::catcher_sse_connect(c_config.as_ptr(), sse_callback, std::ptr::null_mut())
-    };
+    let sse_handle =
+        unsafe { sse::catcher_sse_connect(c_config.as_ptr(), sse_callback, std::ptr::null_mut()) };
     assert!(!sse_handle.is_null(), "SSE connect should succeed");
 
     std::thread::sleep(std::time::Duration::from_millis(500));
@@ -144,14 +151,18 @@ fn s02_sse_connect_and_ready_state() {
     let events = LAST_SSE_EVENT.lock().unwrap().clone();
     assert!(!events.is_empty(), "should have received SSE events");
 
-    unsafe { sse::catcher_sse_close(sse_handle); }
-    unsafe { sse::catcher_sse_destroy(sse_handle); }
+    unsafe {
+        sse::catcher_sse_close(sse_handle);
+    }
+    unsafe {
+        sse::catcher_sse_destroy(sse_handle);
+    }
 }
 
 #[test]
 fn s03_sse_last_event_id() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     // Use a temporary runtime for async mock setup. We keep rt alive so the
     // mock server stays running, but after block_on returns the thread is no
@@ -177,9 +188,8 @@ fn s03_sse_last_event_id() {
     });
     let c_config = CString::new(config.to_string()).unwrap();
 
-    let sse_handle = unsafe {
-        sse::catcher_sse_connect(c_config.as_ptr(), sse_callback, std::ptr::null_mut())
-    };
+    let sse_handle =
+        unsafe { sse::catcher_sse_connect(c_config.as_ptr(), sse_callback, std::ptr::null_mut()) };
     assert!(!sse_handle.is_null());
 
     std::thread::sleep(std::time::Duration::from_millis(500));
@@ -189,6 +199,10 @@ fn s03_sse_last_event_id() {
     // Should have an event ID (might be empty if not yet set, or "42")
     println!("last_event_id: {:?}", id);
 
-    unsafe { sse::catcher_sse_close(sse_handle); }
-    unsafe { sse::catcher_sse_destroy(sse_handle); }
+    unsafe {
+        sse::catcher_sse_close(sse_handle);
+    }
+    unsafe {
+        sse::catcher_sse_destroy(sse_handle);
+    }
 }

--- a/packages/catcher-http/Cargo.toml
+++ b/packages/catcher-http/Cargo.toml
@@ -58,5 +58,6 @@ napi = { version = "2", optional = true, default-features = false, features = ["
 napi-derive = { version = "2", optional = true }
 
 [dev-dependencies]
+catcher-test-support = { path = "../catcher-test-support" }
 tokio-test = "0.4"
 wiremock = "0.6"

--- a/packages/catcher-http/src/ffi/http_ffi.rs
+++ b/packages/catcher-http/src/ffi/http_ffi.rs
@@ -19,12 +19,15 @@ fn response_to_json(resp: &crate::types::http::HttpResponse) -> String {
         "headers": resp.headers,
         "body_base64": body_b64,
         "elapsed_ms": resp.elapsed_ms,
-    }).to_string()
+    })
+    .to_string()
 }
 
 /// 将 HTTP 执行结果序列化为 FFI JSON。
 /// `CatcherError::HttpError`（4xx/5xx）转为正常 response JSON，调用方可读取 status code。
-fn http_result_to_json(result: Result<crate::types::http::HttpResponse, catcher_core::CatcherError>) -> String {
+fn http_result_to_json(
+    result: Result<crate::types::http::HttpResponse, catcher_core::CatcherError>,
+) -> String {
     match result {
         Ok(resp) => response_to_json(&resp),
         Err(catcher_core::CatcherError::HttpError { status, body }) => {
@@ -35,7 +38,8 @@ fn http_result_to_json(result: Result<crate::types::http::HttpResponse, catcher_
                 "headers": {},
                 "body_base64": body_b64,
                 "elapsed_ms": 0u64,
-            }).to_string()
+            })
+            .to_string()
         }
         Err(e) => error_json(&e.to_string()),
     }
@@ -58,8 +62,11 @@ fn ffi_string_to_string(s: FfiString, default: &str) -> String {
 }
 
 fn read_body_bytes(body: *const u8, body_len: usize) -> Vec<u8> {
-    if body.is_null() || body_len == 0 { Vec::new() }
-    else { unsafe { std::slice::from_raw_parts(body, body_len).to_vec() } }
+    if body.is_null() || body_len == 0 {
+        Vec::new()
+    } else {
+        unsafe { std::slice::from_raw_parts(body, body_len).to_vec() }
+    }
 }
 
 fn error_json(msg: &str) -> String {
@@ -67,24 +74,31 @@ fn error_json(msg: &str) -> String {
 }
 
 fn parse_headers_json(headers_json: *const c_char) -> HashMap<String, String> {
-    if headers_json.is_null() { return HashMap::new(); }
+    if headers_json.is_null() {
+        return HashMap::new();
+    }
     let json_str = unsafe {
         match CStr::from_ptr(headers_json).to_str() {
             Ok(s) => s,
             Err(_) => return HashMap::new(),
         }
     };
-    if json_str.is_empty() { return HashMap::new(); }
+    if json_str.is_empty() {
+        return HashMap::new();
+    }
     serde_json::from_str::<HashMap<String, String>>(json_str).unwrap_or_default()
 }
 
-fn invoke_http_callback(
-    callback: EventCallback, event_name: &str, json: String, user_data: usize,
-) {
+fn invoke_http_callback(callback: EventCallback, event_name: &str, json: String, user_data: usize) {
     let c_event = CString::new(event_name.replace('\0', "")).unwrap_or_default();
     let c_json = CString::new(json.replace('\0', "")).unwrap_or_default();
     let json_len = c_json.as_bytes().len();
-    callback(c_event.into_raw(), c_json.into_raw() as *const u8, json_len, user_data as *mut c_void);
+    callback(
+        c_event.into_raw(),
+        c_json.into_raw() as *const u8,
+        json_len,
+        user_data as *mut c_void,
+    );
 }
 
 // ── Lifecycle ──
@@ -94,7 +108,9 @@ fn invoke_http_callback(
 /// API 都安全失败，而不是 use-after-free。
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_client_create(config_json: *const c_char) -> *mut c_void {
-    if config_json.is_null() { return std::ptr::null_mut(); }
+    if config_json.is_null() {
+        return std::ptr::null_mut();
+    }
     let json = CStr::from_ptr(config_json);
     let config: HttpClientConfig = match serde_json::from_str(json.to_str().unwrap_or("")) {
         Ok(c) => c,
@@ -110,7 +126,9 @@ pub unsafe extern "C" fn catcher_http_client_create(config_json: *const c_char) 
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_client_destroy(handle: *mut c_void) {
-    if handle.is_null() { return; }
+    if handle.is_null() {
+        return;
+    }
     let id = handle as usize;
     REGISTRY.remove(id);
 }
@@ -119,23 +137,35 @@ pub unsafe extern "C" fn catcher_http_client_destroy(handle: *mut c_void) {
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_get(
-    handle: *mut c_void, url: FfiString,
-    headers_json: *const c_char, timeout_ms: u32,
-    callback: EventCallback, user_data: *mut c_void,
+    handle: *mut c_void,
+    url: FfiString,
+    headers_json: *const c_char,
+    timeout_ms: u32,
+    callback: EventCallback,
+    user_data: *mut c_void,
 ) {
-    if handle.is_null() { return; }
+    if handle.is_null() {
+        return;
+    }
     let id = handle as usize;
     let url_str = ffi_string_to_string(url, "/");
     let per_request_headers = parse_headers_json(headers_json);
-    let per_request_timeout = if timeout_ms > 0 { Some(timeout_ms as u64) } else { None };
+    let per_request_timeout = if timeout_ms > 0 {
+        Some(timeout_ms as u64)
+    } else {
+        None
+    };
     let ud = user_data as usize;
     let transport = REGISTRY.get(id);
     if let Some(t) = transport {
         runtime().spawn(async move {
             let request = HttpRequest {
-                method: HttpMethod::GET, url: url_str,
-                headers: per_request_headers, body: None,
-                content_type: None, timeout_ms: per_request_timeout,
+                method: HttpMethod::GET,
+                url: url_str,
+                headers: per_request_headers,
+                body: None,
+                content_type: None,
+                timeout_ms: per_request_timeout,
                 ..Default::default()
             };
             let result = t.execute(request).await;
@@ -147,27 +177,40 @@ pub unsafe extern "C" fn catcher_http_get(
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_post(
-    handle: *mut c_void, url: FfiString,
-    body: *const u8, body_len: usize,
+    handle: *mut c_void,
+    url: FfiString,
+    body: *const u8,
+    body_len: usize,
     content_type: FfiString,
-    headers_json: *const c_char, timeout_ms: u32,
-    callback: EventCallback, user_data: *mut c_void,
+    headers_json: *const c_char,
+    timeout_ms: u32,
+    callback: EventCallback,
+    user_data: *mut c_void,
 ) {
-    if handle.is_null() { return; }
+    if handle.is_null() {
+        return;
+    }
     let id = handle as usize;
     let url_str = ffi_string_to_string(url, "/");
     let body_data = read_body_bytes(body, body_len);
     let ct_str = ffi_string_to_string(content_type, "application/octet-stream");
     let per_request_headers = parse_headers_json(headers_json);
-    let per_request_timeout = if timeout_ms > 0 { Some(timeout_ms as u64) } else { None };
+    let per_request_timeout = if timeout_ms > 0 {
+        Some(timeout_ms as u64)
+    } else {
+        None
+    };
     let ud = user_data as usize;
     let transport = REGISTRY.get(id);
     if let Some(t) = transport {
         runtime().spawn(async move {
             let request = HttpRequest {
-                method: HttpMethod::POST, url: url_str,
-                headers: per_request_headers, body: Some(body_data),
-                content_type: Some(ct_str), timeout_ms: per_request_timeout,
+                method: HttpMethod::POST,
+                url: url_str,
+                headers: per_request_headers,
+                body: Some(body_data),
+                content_type: Some(ct_str),
+                timeout_ms: per_request_timeout,
                 ..Default::default()
             };
             let result = t.execute(request).await;
@@ -180,33 +223,55 @@ pub unsafe extern "C" fn catcher_http_post(
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_execute(
     handle: *mut c_void,
-    method: FfiString, url: FfiString,
-    body: *const u8, body_len: usize,
+    method: FfiString,
+    url: FfiString,
+    body: *const u8,
+    body_len: usize,
     content_type: FfiString,
-    headers_json: *const c_char, timeout_ms: u32,
-    callback: EventCallback, user_data: *mut c_void,
+    headers_json: *const c_char,
+    timeout_ms: u32,
+    callback: EventCallback,
+    user_data: *mut c_void,
 ) {
-    if handle.is_null() { return; }
+    if handle.is_null() {
+        return;
+    }
     let id = handle as usize;
     let method_str = ffi_string_to_string(method, "GET");
     let url_str = ffi_string_to_string(url, "/");
     let body_data = if !body.is_null() && body_len > 0 {
         Some(read_body_bytes(body, body_len))
-    } else { None };
+    } else {
+        None
+    };
     let ct_str = {
         let s = ffi_string_to_string(content_type, "");
-        if s.is_empty() { None } else { Some(s) }
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
     };
     let per_request_headers = parse_headers_json(headers_json);
-    let per_request_timeout = if timeout_ms > 0 { Some(timeout_ms as u64) } else { None };
+    let per_request_timeout = if timeout_ms > 0 {
+        Some(timeout_ms as u64)
+    } else {
+        None
+    };
     let ud = user_data as usize;
     let http_method = match method_str.to_uppercase().as_str() {
-        "GET" => HttpMethod::GET, "POST" => HttpMethod::POST,
-        "PUT" => HttpMethod::PUT, "DELETE" => HttpMethod::DELETE,
+        "GET" => HttpMethod::GET,
+        "POST" => HttpMethod::POST,
+        "PUT" => HttpMethod::PUT,
+        "DELETE" => HttpMethod::DELETE,
         "PATCH" => HttpMethod::PATCH,
         other => {
-            invoke_http_callback(callback, "http_result",
-                error_json(&format!("Unsupported HTTP method: {other}")), ud);
+            invoke_http_callback(
+                callback,
+                "http_result",
+                error_json(&format!("Unsupported HTTP method: {other}")),
+                ud,
+            );
             return;
         }
     };
@@ -214,9 +279,12 @@ pub unsafe extern "C" fn catcher_http_execute(
     if let Some(t) = transport {
         runtime().spawn(async move {
             let request = HttpRequest {
-                method: http_method, url: url_str,
-                headers: per_request_headers, body: body_data,
-                content_type: ct_str, timeout_ms: per_request_timeout,
+                method: http_method,
+                url: url_str,
+                headers: per_request_headers,
+                body: body_data,
+                content_type: ct_str,
+                timeout_ms: per_request_timeout,
                 ..Default::default()
             };
             let result = t.execute(request).await;
@@ -235,33 +303,55 @@ pub unsafe extern "C" fn catcher_http_execute(
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_execute_with_id(
     handle: *mut c_void,
-    method: FfiString, url: FfiString,
-    body: *const u8, body_len: usize,
+    method: FfiString,
+    url: FfiString,
+    body: *const u8,
+    body_len: usize,
     content_type: FfiString,
-    headers_json: *const c_char, timeout_ms: u32,
-    callback: EventCallback, user_data: *mut c_void,
+    headers_json: *const c_char,
+    timeout_ms: u32,
+    callback: EventCallback,
+    user_data: *mut c_void,
 ) -> u64 {
-    if handle.is_null() { return 0; }
+    if handle.is_null() {
+        return 0;
+    }
     let id = handle as usize;
     let method_str = ffi_string_to_string(method, "GET");
     let url_str = ffi_string_to_string(url, "/");
     let body_data = if !body.is_null() && body_len > 0 {
         Some(read_body_bytes(body, body_len))
-    } else { None };
+    } else {
+        None
+    };
     let ct_str = {
         let s = ffi_string_to_string(content_type, "");
-        if s.is_empty() { None } else { Some(s) }
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
     };
     let per_request_headers = parse_headers_json(headers_json);
-    let per_request_timeout = if timeout_ms > 0 { Some(timeout_ms as u64) } else { None };
+    let per_request_timeout = if timeout_ms > 0 {
+        Some(timeout_ms as u64)
+    } else {
+        None
+    };
     let ud = user_data as usize;
     let http_method = match method_str.to_uppercase().as_str() {
-        "GET" => HttpMethod::GET, "POST" => HttpMethod::POST,
-        "PUT" => HttpMethod::PUT, "DELETE" => HttpMethod::DELETE,
+        "GET" => HttpMethod::GET,
+        "POST" => HttpMethod::POST,
+        "PUT" => HttpMethod::PUT,
+        "DELETE" => HttpMethod::DELETE,
         "PATCH" => HttpMethod::PATCH,
         other => {
-            invoke_http_callback(callback, "http_result",
-                error_json(&format!("Unsupported HTTP method: {other}")), ud);
+            invoke_http_callback(
+                callback,
+                "http_result",
+                error_json(&format!("Unsupported HTTP method: {other}")),
+                ud,
+            );
             return 0;
         }
     };
@@ -270,12 +360,17 @@ pub unsafe extern "C" fn catcher_http_execute_with_id(
         let (request_id, per_request_token) = t.allocate_pending_request();
         runtime().spawn(async move {
             let request = HttpRequest {
-                method: http_method, url: url_str,
-                headers: per_request_headers, body: body_data,
-                content_type: ct_str, timeout_ms: per_request_timeout,
+                method: http_method,
+                url: url_str,
+                headers: per_request_headers,
+                body: body_data,
+                content_type: ct_str,
+                timeout_ms: per_request_timeout,
                 ..Default::default()
             };
-            let (_rid, result) = t.execute_with_token(request_id, per_request_token, request).await;
+            let (_rid, result) = t
+                .execute_with_token(request_id, per_request_token, request)
+                .await;
             let json = match result {
                 Ok(resp) => {
                     use base64::Engine;
@@ -286,23 +381,27 @@ pub unsafe extern "C" fn catcher_http_execute_with_id(
                         "body_base64": body_b64,
                         "elapsed_ms": resp.elapsed_ms,
                         "request_id": request_id,
-                    }).to_string()
+                    })
+                    .to_string()
                 }
                 Err(catcher_core::CatcherError::HttpError { status, body }) => {
                     use base64::Engine;
-                    let body_b64 = base64::engine::general_purpose::STANDARD.encode(body.as_bytes());
+                    let body_b64 =
+                        base64::engine::general_purpose::STANDARD.encode(body.as_bytes());
                     serde_json::json!({
                         "status": status,
                         "headers": {},
                         "body_base64": body_b64,
                         "elapsed_ms": 0u64,
                         "request_id": request_id,
-                    }).to_string()
+                    })
+                    .to_string()
                 }
                 Err(e) => {
                     let msg = e.to_string();
                     if msg.contains("cancelled") {
-                        serde_json::json!({"type": "cancelled", "request_id": request_id}).to_string()
+                        serde_json::json!({"type": "cancelled", "request_id": request_id})
+                            .to_string()
                     } else {
                         serde_json::json!({"error": msg, "request_id": request_id}).to_string()
                     }
@@ -311,26 +410,36 @@ pub unsafe extern "C" fn catcher_http_execute_with_id(
             invoke_http_callback(callback, "http_result", json, ud);
         });
         request_id
-    } else { 0 }
+    } else {
+        0
+    }
 }
 
 /// Cancel a single in-flight request (N-03). Returns 0 on success, -1 if not found.
 #[no_mangle]
-pub unsafe extern "C" fn catcher_http_cancel_request(
-    handle: *mut c_void, request_id: u64,
-) -> i32 {
-    if handle.is_null() { return -1; }
+pub unsafe extern "C" fn catcher_http_cancel_request(handle: *mut c_void, request_id: u64) -> i32 {
+    if handle.is_null() {
+        return -1;
+    }
     let id = handle as usize;
     if let Some(transport) = REGISTRY.get(id) {
-        if transport.cancel_request(request_id) { 0 } else { -1 }
-    } else { -1 }
+        if transport.cancel_request(request_id) {
+            0
+        } else {
+            -1
+        }
+    } else {
+        -1
+    }
 }
 
 // ── Runtime control (unchanged) ──
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_circuit_breaker_state(handle: *mut c_void) -> *mut c_char {
-    if handle.is_null() { return std::ptr::null_mut(); }
+    if handle.is_null() {
+        return std::ptr::null_mut();
+    }
     let id = handle as usize;
     let state = REGISTRY.get(id).and_then(|t| t.circuit_breaker_state());
     let json = match state {
@@ -342,7 +451,9 @@ pub unsafe extern "C" fn catcher_http_circuit_breaker_state(handle: *mut c_void)
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_metrics(handle: *mut c_void) -> *mut c_char {
-    if handle.is_null() { return std::ptr::null_mut(); }
+    if handle.is_null() {
+        return std::ptr::null_mut();
+    }
     let id = handle as usize;
     let snapshot = REGISTRY.get(id).map(|t| t.metrics());
     let json = match snapshot {
@@ -357,7 +468,9 @@ pub unsafe extern "C" fn catcher_http_metrics(handle: *mut c_void) -> *mut c_cha
 /// 返回 0 成功，1 句柄无效，2 重建失败。
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_network_changed(handle: *mut c_void) -> i32 {
-    if handle.is_null() { return 1; }
+    if handle.is_null() {
+        return 1;
+    }
     let id = handle as usize;
     match REGISTRY.get(id) {
         Some(transport) => match transport.network_changed() {
@@ -370,7 +483,9 @@ pub unsafe extern "C" fn catcher_http_network_changed(handle: *mut c_void) -> i3
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_client_cancel_all(handle: *mut c_void) {
-    if handle.is_null() { return; }
+    if handle.is_null() {
+        return;
+    }
     let id = handle as usize;
     if let Some(transport) = REGISTRY.get(id) {
         transport.cancel_all();
@@ -379,55 +494,83 @@ pub unsafe extern "C" fn catcher_http_client_cancel_all(handle: *mut c_void) {
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_adaptive_timeout_config(
-    handle: *mut c_void, enabled: i32,
-    min_timeout_ms: u32, max_timeout_ms: u32,
-    multiplier_scaled: u32, window_size: u32,
+    handle: *mut c_void,
+    enabled: i32,
+    min_timeout_ms: u32,
+    max_timeout_ms: u32,
+    multiplier_scaled: u32,
+    window_size: u32,
 ) {
-    if handle.is_null() { return; }
+    if handle.is_null() {
+        return;
+    }
     let id = handle as usize;
     if let Some(transport) = REGISTRY.get(id) {
         if enabled != 0 {
             transport.set_adaptive_timeout(
-                min_timeout_ms as u64, max_timeout_ms as u64,
-                multiplier_scaled as f64 / 1000.0, window_size as usize,
+                min_timeout_ms as u64,
+                max_timeout_ms as u64,
+                multiplier_scaled as f64 / 1000.0,
+                window_size as usize,
             );
         } else {
             transport.disable_adaptive_timeout();
         }
     }
-
 }
 // N-02: Streaming download C ABI
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_execute_stream(
     handle: *mut c_void,
-    method: FfiString, url: FfiString,
-    body: *const u8, body_len: usize,
+    method: FfiString,
+    url: FfiString,
+    body: *const u8,
+    body_len: usize,
     content_type: FfiString,
-    headers_json: *const c_char, timeout_ms: u32,
-    callback: EventCallback, user_data: *mut c_void,
+    headers_json: *const c_char,
+    timeout_ms: u32,
+    callback: EventCallback,
+    user_data: *mut c_void,
 ) -> u64 {
-    if handle.is_null() { return 0; }
+    if handle.is_null() {
+        return 0;
+    }
     let id = handle as usize;
     let method_str = ffi_string_to_string(method, "GET");
     let url_str = ffi_string_to_string(url, "/");
     let body_data = if !body.is_null() && body_len > 0 {
         Some(read_body_bytes(body, body_len))
-    } else { None };
+    } else {
+        None
+    };
     let ct_str = {
         let s = ffi_string_to_string(content_type, "");
-        if s.is_empty() { None } else { Some(s) }
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
     };
     let per_request_headers = parse_headers_json(headers_json);
-    let per_request_timeout = if timeout_ms > 0 { Some(timeout_ms as u64) } else { None };
+    let per_request_timeout = if timeout_ms > 0 {
+        Some(timeout_ms as u64)
+    } else {
+        None
+    };
     let ud = user_data as usize;
     let http_method = match method_str.to_uppercase().as_str() {
-        "GET" => HttpMethod::GET, "POST" => HttpMethod::POST,
-        "PUT" => HttpMethod::PUT, "DELETE" => HttpMethod::DELETE,
+        "GET" => HttpMethod::GET,
+        "POST" => HttpMethod::POST,
+        "PUT" => HttpMethod::PUT,
+        "DELETE" => HttpMethod::DELETE,
         "PATCH" => HttpMethod::PATCH,
         other => {
-            invoke_http_callback(callback, "stream_error",
-                serde_json::json!({"error": format!("Unsupported method: {other}")}).to_string(), ud);
+            invoke_http_callback(
+                callback,
+                "stream_error",
+                serde_json::json!({"error": format!("Unsupported method: {other}")}).to_string(),
+                ud,
+            );
             return 0;
         }
     };
@@ -465,7 +608,9 @@ pub unsafe extern "C" fn catcher_http_execute_stream(
             }).await;
         });
         request_id
-    } else { 0 }
+    } else {
+        0
+    }
 }
 
 // ── Multipart upload (B-02) ──────────────────────────────────
@@ -477,9 +622,9 @@ pub unsafe extern "C" fn catcher_http_execute_stream(
 #[repr(C)]
 pub struct FfiMultipartPart {
     pub name: *const c_char,
-    pub value_or_filename: *const c_char,  // text value OR filename
-    pub content_type: *const c_char,        // null for text parts
-    pub data: *const u8,                     // null for text parts
+    pub value_or_filename: *const c_char, // text value OR filename
+    pub content_type: *const c_char,      // null for text parts
+    pub data: *const u8,                  // null for text parts
     pub data_len: usize,
 }
 
@@ -491,7 +636,7 @@ pub struct FfiMultipartPart {
 #[no_mangle]
 pub unsafe extern "C" fn catcher_http_multipart(
     handle: *mut c_void,
-    method: *const c_char,       // "POST" or "PUT"
+    method: *const c_char, // "POST" or "PUT"
     url: FfiString,
     parts: *const FfiMultipartPart,
     parts_count: usize,
@@ -500,7 +645,9 @@ pub unsafe extern "C" fn catcher_http_multipart(
     callback: Option<EventCallback>,
     user_data: usize,
 ) {
-    if handle.is_null() { return; }
+    if handle.is_null() {
+        return;
+    }
     let callback = match callback {
         Some(cb) => cb,
         None => return,
@@ -519,29 +666,56 @@ pub unsafe extern "C" fn catcher_http_multipart(
 
     let url_str = ffi_string_to_string(url, "");
     let per_request_headers = parse_headers_json(headers_json);
-    let per_request_timeout = if timeout_ms > 0 { Some(timeout_ms) } else { None };
+    let per_request_timeout = if timeout_ms > 0 {
+        Some(timeout_ms)
+    } else {
+        None
+    };
 
     // Build multipart form from FFI parts array
     let mut form = crate::transport::multipart::MultipartForm::new();
     if !parts.is_null() && parts_count > 0 {
         let parts_slice = std::slice::from_raw_parts(parts, parts_count);
         for part in parts_slice {
-            let name = if part.name.is_null() { continue; }
-            else { CStr::from_ptr(part.name).to_str().unwrap_or("").to_string() };
-            if name.is_empty() { continue; }
+            let name = if part.name.is_null() {
+                continue;
+            } else {
+                CStr::from_ptr(part.name).to_str().unwrap_or("").to_string()
+            };
+            if name.is_empty() {
+                continue;
+            }
 
             if part.data.is_null() || part.data_len == 0 {
                 // Text field
-                let value = if part.value_or_filename.is_null() { String::new() }
-                else { CStr::from_ptr(part.value_or_filename).to_str().unwrap_or("").to_string() };
+                let value = if part.value_or_filename.is_null() {
+                    String::new()
+                } else {
+                    CStr::from_ptr(part.value_or_filename)
+                        .to_str()
+                        .unwrap_or("")
+                        .to_string()
+                };
                 form = form.text(name, value);
             } else {
                 // Binary/file field
                 let data = std::slice::from_raw_parts(part.data, part.data_len).to_vec();
-                let filename = if part.value_or_filename.is_null() { "file".to_string() }
-                else { CStr::from_ptr(part.value_or_filename).to_str().unwrap_or("file").to_string() };
-                let ct = if part.content_type.is_null() { "application/octet-stream".to_string() }
-                else { CStr::from_ptr(part.content_type).to_str().unwrap_or("application/octet-stream").to_string() };
+                let filename = if part.value_or_filename.is_null() {
+                    "file".to_string()
+                } else {
+                    CStr::from_ptr(part.value_or_filename)
+                        .to_str()
+                        .unwrap_or("file")
+                        .to_string()
+                };
+                let ct = if part.content_type.is_null() {
+                    "application/octet-stream".to_string()
+                } else {
+                    CStr::from_ptr(part.content_type)
+                        .to_str()
+                        .unwrap_or("application/octet-stream")
+                        .to_string()
+                };
                 form = form.file(name, filename, ct, data);
             }
         }

--- a/packages/catcher-http/src/ffi/quality_ffi.rs
+++ b/packages/catcher-http/src/ffi/quality_ffi.rs
@@ -22,9 +22,7 @@ static EVALUATOR: std::sync::OnceLock<SharedEvaluator> = std::sync::OnceLock::ne
 
 fn evaluator() -> SharedEvaluator {
     EVALUATOR
-        .get_or_init(|| {
-            Arc::new(tokio::sync::Mutex::new(NetworkQualityEvaluator::new(50)))
-        })
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(NetworkQualityEvaluator::new(50))))
         .clone()
 }
 
@@ -136,7 +134,10 @@ pub unsafe extern "C" fn catcher_quality_subscribe(
     let host_str = ffi_string_to_string(host, "https://www.example.com");
     let ud = user_data as usize;
     let sub = crate::observability::network_quality::QualitySubscription::start(
-        host_str, interval_ms as u64, callback, ud,
+        host_str,
+        interval_ms as u64,
+        callback,
+        ud,
     );
     let boxed = Box::new(sub);
     let ptr = Box::into_raw(boxed) as *mut c_void;
@@ -146,7 +147,9 @@ pub unsafe extern "C" fn catcher_quality_subscribe(
 
 #[no_mangle]
 pub unsafe extern "C" fn catcher_quality_unsubscribe(sub_handle: *mut c_void) {
-    if sub_handle.is_null() { return; }
+    if sub_handle.is_null() {
+        return;
+    }
     // 先从订阅表移除，仅当句柄确实在表中时才回收 —
     // 重复 unsubscribe 或传入无效句柄都安全返回，避免 double-free/UAF
     {
@@ -156,6 +159,7 @@ pub unsafe extern "C" fn catcher_quality_unsubscribe(sub_handle: *mut c_void) {
         };
         subs.remove(pos);
     }
-    let sub: Box<crate::observability::network_quality::QualitySubscription> = Box::from_raw(sub_handle as *mut _);
+    let sub: Box<crate::observability::network_quality::QualitySubscription> =
+        Box::from_raw(sub_handle as *mut _);
     sub.unsubscribe();
 }

--- a/packages/catcher-http/src/ffi/sse_ffi.rs
+++ b/packages/catcher-http/src/ffi/sse_ffi.rs
@@ -47,7 +47,8 @@ fn build_sse_event_json(event_type: &str, data: &str) -> String {
     serde_json::json!({
         "type": event_type,
         "data": data,
-    }).to_string()
+    })
+    .to_string()
 }
 
 fn invoke_sse_callback(callback: EventCallback, json: String, user_data: usize) {
@@ -191,42 +192,42 @@ pub unsafe extern "C" fn catcher_sse_connect(
         });
         rt.block_on(async move {
             match SseClient::connect(config).await {
-            Ok(client) => {
-                // Send open event
-                let open_json = build_sse_event_json("open", "");
-                invoke_sse_callback(callback_ptr, open_json, ud);
+                Ok(client) => {
+                    // Send open event
+                    let open_json = build_sse_event_json("open", "");
+                    invoke_sse_callback(callback_ptr, open_json, ud);
 
-                // Store client for later operations (close, ready_state, etc.)
-                let client_arc = Arc::new(TokioMutex::new(client));
-                let id = SSE_REGISTRY.insert(client_arc.clone());
+                    // Store client for later operations (close, ready_state, etc.)
+                    let client_arc = Arc::new(TokioMutex::new(client));
+                    let id = SSE_REGISTRY.insert(client_arc.clone());
 
-                // Spawn background task to forward SSE lines to callback
-                sse_runtime().spawn(async move {
-                    loop {
-                        let mut c = client_arc.lock().await;
-                        let line_result = c.next_line().await;
-                        drop(c); // release lock before invoking callback
-                        match line_result {
-                            Some(Ok(line)) => {
-                                let json = build_sse_event_json("data", &line);
-                                invoke_sse_callback(callback_ptr, json, ud);
-                            }
-                            Some(Err(e)) => {
-                                let err_json = build_sse_event_json("error", &e.to_string());
-                                invoke_sse_callback(callback_ptr, err_json, ud);
-                            }
-                            None => {
-                                let done_json = build_sse_event_json("close", "");
-                                invoke_sse_callback(callback_ptr, done_json, ud);
-                                break;
+                    // Spawn background task to forward SSE lines to callback
+                    sse_runtime().spawn(async move {
+                        loop {
+                            let mut c = client_arc.lock().await;
+                            let line_result = c.next_line().await;
+                            drop(c); // release lock before invoking callback
+                            match line_result {
+                                Some(Ok(line)) => {
+                                    let json = build_sse_event_json("data", &line);
+                                    invoke_sse_callback(callback_ptr, json, ud);
+                                }
+                                Some(Err(e)) => {
+                                    let err_json = build_sse_event_json("error", &e.to_string());
+                                    invoke_sse_callback(callback_ptr, err_json, ud);
+                                }
+                                None => {
+                                    let done_json = build_sse_event_json("close", "");
+                                    invoke_sse_callback(callback_ptr, done_json, ud);
+                                    break;
+                                }
                             }
                         }
-                    }
-                });
+                    });
 
-                id
-            }
-            Err(_) => 0usize,
+                    id
+                }
+                Err(_) => 0usize,
             }
         })
     });
@@ -245,7 +246,8 @@ pub unsafe extern "C" fn catcher_sse_ready_state(sse_handle: *mut c_void) -> i32
         return -1;
     }
     let id = sse_handle as usize;
-    SSE_REGISTRY.get(id)
+    SSE_REGISTRY
+        .get(id)
         .map(|client| match client.blocking_lock().ready_state() {
             SseReadyState::Connecting => 0,
             SseReadyState::Open => 1,
@@ -262,7 +264,8 @@ pub unsafe extern "C" fn catcher_sse_last_event_id(sse_handle: *mut c_void) -> *
         return std::ptr::null_mut();
     }
     let id = sse_handle as usize;
-    SSE_REGISTRY.get(id)
+    SSE_REGISTRY
+        .get(id)
         .map(|client| {
             let last_id = client.blocking_lock().last_event_id();
             CString::new(last_id).unwrap_or_default().into_raw()

--- a/packages/catcher-http/src/lib.rs
+++ b/packages/catcher-http/src/lib.rs
@@ -10,20 +10,18 @@
 //! - FFI C ABI for cross-language bindings
 //! - SSE streaming client with auto-reconnect
 
-pub mod types;
-pub mod transport;
+pub mod ffi;
+pub mod observability;
 pub mod resilience;
 pub mod scheduler;
-pub mod observability;
-pub mod ffi;
 pub mod sse;
+pub mod transport;
+pub mod types;
 
 // Re-export key types
-pub use transport::HttpTransport;
-pub use resilience::{
-    build_retry_policy, retry_with_backoff, AdaptiveTimeout, CircuitBreaker,
-};
-pub use scheduler::{concurrency_for_quality, PriorityRequestQueue};
-pub use observability::{MetricsCollector, MetricsSnapshot, NetworkQualityEvaluator};
-pub use sse::{SseClient, SseStream};
 pub use catcher_core::types::sse::{SseClientConfig, SseMethod, SseReconnectConfig};
+pub use observability::{MetricsCollector, MetricsSnapshot, NetworkQualityEvaluator};
+pub use resilience::{build_retry_policy, retry_with_backoff, AdaptiveTimeout, CircuitBreaker};
+pub use scheduler::{concurrency_for_quality, PriorityRequestQueue};
+pub use sse::{SseClient, SseStream};
+pub use transport::HttpTransport;

--- a/packages/catcher-http/src/observability/metrics.rs
+++ b/packages/catcher-http/src/observability/metrics.rs
@@ -1,7 +1,7 @@
 use catcher_core::types::observability::Priority;
 use serde::Serialize;
-use std::sync::{Arc, Weak};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
 
 /// 轻量级指标收集器（无外部依赖，纯 atomic 计数）
 #[derive(Default)]

--- a/packages/catcher-http/src/observability/network_quality.rs
+++ b/packages/catcher-http/src/observability/network_quality.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
-use catcher_core::CatcherError;
 use catcher_core::types::observability::*;
+use catcher_core::CatcherError;
 
 /// 网络质量评估器：HTTP HEAD RTT + 滑动窗口 + 综合评分
 pub struct NetworkQualityEvaluator {
@@ -143,7 +143,7 @@ fn classify_quality(snapshot: &RttSnapshot) -> NetworkQualityLevel {
 /// 质量订阅 — N-04 实时推送
 pub struct QualitySubscription {
     cancel_tx: tokio::sync::watch::Sender<bool>,
-    _task: tokio::task::JoinHandle<()>,
+    task: tokio::task::JoinHandle<()>,
 }
 
 impl QualitySubscription {
@@ -206,12 +206,13 @@ impl QualitySubscription {
             }
         });
 
-        Self { cancel_tx, _task: task }
+        Self { cancel_tx, task }
     }
 
     /// 取消订阅，停止后台 task
     pub fn unsubscribe(self) {
         let _ = self.cancel_tx.send(true);
+        self.task.abort();
     }
 }
 
@@ -264,7 +265,10 @@ mod tests {
         // degrading: level > previous_level
         // stable: level == previous_level
         use std::cmp::Ordering;
-        fn compute_trend(level: NetworkQualityLevel, prev: Option<NetworkQualityLevel>) -> &'static str {
+        fn compute_trend(
+            level: NetworkQualityLevel,
+            prev: Option<NetworkQualityLevel>,
+        ) -> &'static str {
             match prev {
                 None => "unknown",
                 Some(p) => match level.cmp(&p) {
@@ -275,56 +279,78 @@ mod tests {
             }
         }
         // Bad > Poor > Fair > Good > Excellent
-        assert_eq!(compute_trend(NetworkQualityLevel::Excellent, None), "unknown");
-        assert_eq!(compute_trend(NetworkQualityLevel::Good, Some(NetworkQualityLevel::Excellent)), "degrading");
-        assert_eq!(compute_trend(NetworkQualityLevel::Poor, Some(NetworkQualityLevel::Bad)), "improving");
-        assert_eq!(compute_trend(NetworkQualityLevel::Good, Some(NetworkQualityLevel::Good)), "stable");
-        assert_eq!(compute_trend(NetworkQualityLevel::Fair, Some(NetworkQualityLevel::Poor)), "improving");
+        assert_eq!(
+            compute_trend(NetworkQualityLevel::Excellent, None),
+            "unknown"
+        );
+        assert_eq!(
+            compute_trend(
+                NetworkQualityLevel::Good,
+                Some(NetworkQualityLevel::Excellent)
+            ),
+            "degrading"
+        );
+        assert_eq!(
+            compute_trend(NetworkQualityLevel::Poor, Some(NetworkQualityLevel::Bad)),
+            "improving"
+        );
+        assert_eq!(
+            compute_trend(NetworkQualityLevel::Good, Some(NetworkQualityLevel::Good)),
+            "stable"
+        );
+        assert_eq!(
+            compute_trend(NetworkQualityLevel::Fair, Some(NetworkQualityLevel::Poor)),
+            "improving"
+        );
     }
 
     #[test]
     fn ns04_classify_quality_levels() {
         let mut eval = NetworkQualityEvaluator::new(10);
         // Excellent: avg_rtt < 80
-        eval.record_rtt(30); eval.record_rtt(40); eval.record_rtt(50);
+        eval.record_rtt(30);
+        eval.record_rtt(40);
+        eval.record_rtt(50);
         assert_eq!(eval.evaluate().level, NetworkQualityLevel::Excellent);
 
         let mut eval = NetworkQualityEvaluator::new(10);
         // Good: avg_rtt < 200
-        eval.record_rtt(100); eval.record_rtt(150);
+        eval.record_rtt(100);
+        eval.record_rtt(150);
         assert_eq!(eval.evaluate().level, NetworkQualityLevel::Good);
 
         let mut eval = NetworkQualityEvaluator::new(10);
         // Bad: avg_rtt >= 1000
-        eval.record_rtt(1200); eval.record_rtt(1500);
+        eval.record_rtt(1200);
+        eval.record_rtt(1500);
         assert_eq!(eval.evaluate().level, NetworkQualityLevel::Bad);
     }
 
     #[tokio::test]
     async fn ns04_subscription_starts_and_unsubscribes() {
         extern "C" fn noop_callback(
-            _et: *const std::ffi::c_char, _ed: *const u8, _el: usize, _ud: *mut std::ffi::c_void,
-        ) {}
-        let sub = QualitySubscription::start(
-            "http://127.0.0.1:1".to_string(),
-            500,
-            noop_callback,
-            0,
-        );
+            _et: *const std::ffi::c_char,
+            _ed: *const u8,
+            _el: usize,
+            _ud: *mut std::ffi::c_void,
+        ) {
+        }
+        let sub =
+            QualitySubscription::start("http://127.0.0.1:1".to_string(), 500, noop_callback, 0);
         sub.unsubscribe();
     }
 
     #[tokio::test]
     async fn ns04_subscription_measurement_failure_no_crash() {
         extern "C" fn noop_callback(
-            _et: *const std::ffi::c_char, _ed: *const u8, _el: usize, _ud: *mut std::ffi::c_void,
-        ) {}
-        let sub = QualitySubscription::start(
-            "http://127.0.0.1:1".to_string(),
-            100,
-            noop_callback,
-            0,
-        );
+            _et: *const std::ffi::c_char,
+            _ed: *const u8,
+            _el: usize,
+            _ud: *mut std::ffi::c_void,
+        ) {
+        }
+        let sub =
+            QualitySubscription::start("http://127.0.0.1:1".to_string(), 100, noop_callback, 0);
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         sub.unsubscribe();
     }
@@ -343,10 +369,16 @@ mod tests {
     #[tokio::test]
     async fn ns04_multiple_subscribers_independent() {
         extern "C" fn noop_callback(
-            _et: *const std::ffi::c_char, _ed: *const u8, _el: usize, _ud: *mut std::ffi::c_void,
-        ) {}
-        let sub1 = QualitySubscription::start("http://127.0.0.1:1".to_string(), 500, noop_callback, 0);
-        let sub2 = QualitySubscription::start("http://127.0.0.1:1".to_string(), 500, noop_callback, 0);
+            _et: *const std::ffi::c_char,
+            _ed: *const u8,
+            _el: usize,
+            _ud: *mut std::ffi::c_void,
+        ) {
+        }
+        let sub1 =
+            QualitySubscription::start("http://127.0.0.1:1".to_string(), 500, noop_callback, 0);
+        let sub2 =
+            QualitySubscription::start("http://127.0.0.1:1".to_string(), 500, noop_callback, 0);
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         sub1.unsubscribe();
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;

--- a/packages/catcher-http/src/resilience/backoff.rs
+++ b/packages/catcher-http/src/resilience/backoff.rs
@@ -41,7 +41,11 @@ mod tests {
     }
 
     /// Extract delay as millis (f64) from RetryDecision
-    fn delay_ms(policy: &retry_policies::policies::ExponentialBackoff, start: SystemTime, n: u32) -> Option<f64> {
+    fn delay_ms(
+        policy: &retry_policies::policies::ExponentialBackoff,
+        start: SystemTime,
+        n: u32,
+    ) -> Option<f64> {
         match policy.should_retry(start, n) {
             retry_policies::RetryDecision::Retry { execute_after } => {
                 Some(execute_after.duration_since(start).unwrap().as_secs_f64() * 1000.0)
@@ -81,9 +85,18 @@ mod tests {
         let d1 = delay_ms(&policy, start, 1).unwrap();
         let d2 = delay_ms(&policy, start, 2).unwrap();
 
-        assert!((d0 - 100.0).abs() < 2.0, "attempt 0: expected ~100ms, got {d0:.3}ms");
-        assert!((d1 - 200.0).abs() < 2.0, "attempt 1: expected ~200ms, got {d1:.3}ms");
-        assert!((d2 - 400.0).abs() < 2.0, "attempt 2: expected ~400ms, got {d2:.3}ms");
+        assert!(
+            (d0 - 100.0).abs() < 2.0,
+            "attempt 0: expected ~100ms, got {d0:.3}ms"
+        );
+        assert!(
+            (d1 - 200.0).abs() < 2.0,
+            "attempt 1: expected ~200ms, got {d1:.3}ms"
+        );
+        assert!(
+            (d2 - 400.0).abs() < 2.0,
+            "attempt 2: expected ~400ms, got {d2:.3}ms"
+        );
     }
 
     #[test]
@@ -96,8 +109,7 @@ mod tests {
         // The calculated backoff grows exponentially but jitter may push it below min_backoff.
         // Verify delays are within a reasonable range [0, max_backoff + overhead].
         for attempt in 0..3 {
-            let d = delay_ms(&policy, start, attempt)
-                .expect("expected Retry decision");
+            let d = delay_ms(&policy, start, attempt).expect("expected Retry decision");
             assert!(
                 (0.0..=10_002.0).contains(&d),
                 "attempt {attempt}: delay {d:.3}ms out of [0ms, 10000ms] range"

--- a/packages/catcher-http/src/resilience/circuit_breaker.rs
+++ b/packages/catcher-http/src/resilience/circuit_breaker.rs
@@ -1,5 +1,5 @@
-use catcher_core::CatcherError;
 use catcher_core::types::resilience::{CbState, CircuitBreakerConfig};
+use catcher_core::CatcherError;
 use parking_lot::Mutex;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/packages/catcher-http/src/resilience/retry.rs
+++ b/packages/catcher-http/src/resilience/retry.rs
@@ -1,6 +1,6 @@
-use catcher_core::{CatcherError, ErrorCategory};
-use catcher_core::types::resilience::{BackoffKind, RetryConfig};
 use backon::{ConstantBuilder, ExponentialBuilder, Retryable};
+use catcher_core::types::resilience::{BackoffKind, RetryConfig};
+use catcher_core::{CatcherError, ErrorCategory};
 use std::cell::Cell;
 use std::time::Duration;
 

--- a/packages/catcher-http/src/scheduler/priority_queue.rs
+++ b/packages/catcher-http/src/scheduler/priority_queue.rs
@@ -2,9 +2,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Semaphore};
 
-use catcher_core::CatcherError;
 use catcher_core::types::observability::Priority;
 use catcher_core::types::scheduler::QueueConfig;
+use catcher_core::CatcherError;
 
 type BoxedFuture<T> = Pin<Box<dyn std::future::Future<Output = Result<T, CatcherError>> + Send>>;
 
@@ -30,8 +30,7 @@ pub struct PriorityRequestQueue<T: Send + 'static> {
 
 impl<T: Send + 'static> PriorityRequestQueue<T> {
     pub fn new(config: QueueConfig) -> Self {
-        let (high_tx, mut high_rx) =
-            mpsc::channel::<PrioritizedTask<T>>(config.queue_capacity);
+        let (high_tx, mut high_rx) = mpsc::channel::<PrioritizedTask<T>>(config.queue_capacity);
         let (low_tx, mut low_rx) = mpsc::channel::<PrioritizedTask<T>>(config.queue_capacity);
         let sem = Arc::new(Semaphore::new(config.max_concurrency));
 

--- a/packages/catcher-http/src/sse/client.rs
+++ b/packages/catcher-http/src/sse/client.rs
@@ -79,7 +79,16 @@ impl SseClient {
                 // Mark as Connecting before each connection attempt
                 *ready_state_bg.lock().unwrap() = SseReadyState::Connecting;
 
-                match connect_once(&client, &config_clone, &lines_tx, &last_event_id_bg, &ready_state_bg, &reconnect_delay_bg).await {
+                match connect_once(
+                    &client,
+                    &config_clone,
+                    &lines_tx,
+                    &last_event_id_bg,
+                    &ready_state_bg,
+                    &reconnect_delay_bg,
+                )
+                .await
+                {
                     Ok(()) => {
                         // Stream ended normally — check if we should reconnect
                         if cancel_rx.try_recv().is_ok() {
@@ -183,7 +192,6 @@ async fn connect_once(
     ready_state: &Arc<Mutex<SseReadyState>>,
     reconnect_delay: &Arc<Mutex<Option<u64>>>,
 ) -> Result<(), CatcherError> {
-
     let method = match config.method {
         catcher_core::types::sse::SseMethod::GET => reqwest::Method::GET,
         catcher_core::types::sse::SseMethod::POST => reqwest::Method::POST,
@@ -247,9 +255,7 @@ async fn connect_once(
         buffer.push_str(&String::from_utf8_lossy(&bytes));
 
         while let Some(newline_pos) = buffer.find('\n') {
-            let line = buffer[..newline_pos]
-                .trim_end_matches('\r')
-                .to_string();
+            let line = buffer[..newline_pos].trim_end_matches('\r').to_string();
             buffer.drain(..newline_pos + 1);
 
             match route_line(&line) {
@@ -334,9 +340,9 @@ mod tests {
     async fn rc1_basic_consumption() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: hello\n\ndata: world\n\n",
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("data: hello\n\ndata: world\n\n"),
+            )
             .mount(&server)
             .await;
 
@@ -359,18 +365,14 @@ mod tests {
 
         // First response: sends id + data then closes
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "id: abc123\ndata: first\n\n",
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("id: abc123\ndata: first\n\n"))
             .up_to_n_times(1)
             .mount(&server)
             .await;
 
         // Second response: after reconnect with Last-Event-ID
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: second\n\n",
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("data: second\n\n"))
             .mount(&server)
             .await;
 
@@ -393,9 +395,7 @@ mod tests {
     async fn rc3_close_stops() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: ongoing\n",
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("data: ongoing\n"))
             .mount(&server)
             .await;
 
@@ -426,15 +426,13 @@ mod tests {
         let mut client = SseClient::connect(config).await.unwrap();
 
         // Should get no lines, and eventually the channel closes
-        let next = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            client.next_line(),
-        ).await;
+        let next =
+            tokio::time::timeout(std::time::Duration::from_secs(2), client.next_line()).await;
         // Either None (channel closed) or timeout — both acceptable
         match next {
             Ok(Some(_)) => panic!("Expected no data after 204"),
             Ok(None) => {} // Channel closed — good
-            Err(_) => {} // Timeout — acceptable, 204 handling closes the loop
+            Err(_) => {}   // Timeout — acceptable, 204 handling closes the loop
         }
 
         client.close();
@@ -445,9 +443,7 @@ mod tests {
     async fn rc5_ready_state_transitions() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: hi\n\n",
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("data: hi\n\n"))
             .mount(&server)
             .await;
 
@@ -472,9 +468,7 @@ mod tests {
     async fn rc6_stream_trait_consumption() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: a\ndata: b\n\n",
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("data: a\ndata: b\n\n"))
             .mount(&server)
             .await;
 

--- a/packages/catcher-http/src/sse/router.rs
+++ b/packages/catcher-http/src/sse/router.rs
@@ -48,7 +48,10 @@ mod tests {
 
     #[test]
     fn test_03_comment_silent() {
-        assert!(matches!(route_line(": this is a comment"), RouteAction::Silent));
+        assert!(matches!(
+            route_line(": this is a comment"),
+            RouteAction::Silent
+        ));
     }
 
     #[test]
@@ -60,17 +63,23 @@ mod tests {
 
     #[test]
     fn test_05_id_standard() {
-        assert!(matches!(route_line("id: msg_001"), RouteAction::SetLastEventId(id) if id == "msg_001"));
+        assert!(
+            matches!(route_line("id: msg_001"), RouteAction::SetLastEventId(id) if id == "msg_001")
+        );
     }
 
     #[test]
     fn test_06_id_no_space() {
-        assert!(matches!(route_line("id:msg_002"), RouteAction::SetLastEventId(id) if id == "msg_002"));
+        assert!(
+            matches!(route_line("id:msg_002"), RouteAction::SetLastEventId(id) if id == "msg_002")
+        );
     }
 
     #[test]
     fn test_07_id_multi_space() {
-        assert!(matches!(route_line("id:  multi  space"), RouteAction::SetLastEventId(id) if id == "multi  space"));
+        assert!(
+            matches!(route_line("id:  multi  space"), RouteAction::SetLastEventId(id) if id == "multi  space")
+        );
     }
 
     #[test]
@@ -87,12 +96,18 @@ mod tests {
 
     #[test]
     fn test_10_retry_standard() {
-        assert!(matches!(route_line("retry: 5000"), RouteAction::SetRetry(5000)));
+        assert!(matches!(
+            route_line("retry: 5000"),
+            RouteAction::SetRetry(5000)
+        ));
     }
 
     #[test]
     fn test_11_retry_no_space() {
-        assert!(matches!(route_line("retry:1000"), RouteAction::SetRetry(1000)));
+        assert!(matches!(
+            route_line("retry:1000"),
+            RouteAction::SetRetry(1000)
+        ));
     }
 
     #[test]
@@ -120,7 +135,9 @@ mod tests {
 
     #[test]
     fn test_16_data_json() {
-        assert!(matches!(route_line(r#"data: {"type":"start"}"#), RouteAction::Yield(l) if l == r#"data: {"type":"start"}"#));
+        assert!(
+            matches!(route_line(r#"data: {"type":"start"}"#), RouteAction::Yield(l) if l == r#"data: {"type":"start"}"#)
+        );
     }
 
     #[test]
@@ -135,7 +152,9 @@ mod tests {
 
     #[test]
     fn test_19_event() {
-        assert!(matches!(route_line("event: message_start"), RouteAction::Yield(l) if l == "event: message_start"));
+        assert!(
+            matches!(route_line("event: message_start"), RouteAction::Yield(l) if l == "event: message_start")
+        );
     }
 
     #[test]
@@ -145,7 +164,9 @@ mod tests {
 
     #[test]
     fn test_21_custom_prefix() {
-        assert!(matches!(route_line("custom: value"), RouteAction::Yield(l) if l == "custom: value"));
+        assert!(
+            matches!(route_line("custom: value"), RouteAction::Yield(l) if l == "custom: value")
+        );
     }
 
     #[test]
@@ -155,7 +176,9 @@ mod tests {
 
     #[test]
     fn test_23_uppercase_id() {
-        assert!(matches!(route_line("ID: uppercase"), RouteAction::Yield(l) if l == "ID: uppercase"));
+        assert!(
+            matches!(route_line("ID: uppercase"), RouteAction::Yield(l) if l == "ID: uppercase")
+        );
     }
 
     #[test]

--- a/packages/catcher-http/src/sse/stream.rs
+++ b/packages/catcher-http/src/sse/stream.rs
@@ -197,9 +197,9 @@ mod tests {
     async fn rs1_full_event_consumption() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: Hello\n\ndata: World\n\n",
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("data: Hello\n\ndata: World\n\n"),
+            )
             .mount(&server)
             .await;
 
@@ -213,9 +213,10 @@ mod tests {
     async fn rs2_control_line_filtering() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                ": comment\ndata: A\nid: 1\n\ndata: B\n",
-            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(": comment\ndata: A\nid: 1\n\ndata: B\n"),
+            )
             .mount(&server)
             .await;
 
@@ -230,9 +231,7 @@ mod tests {
     async fn rs3_crlf_tolerance() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: X\r\n\r\n",
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("data: X\r\n\r\n"))
             .mount(&server)
             .await;
 
@@ -263,9 +262,7 @@ mod tests {
     async fn rs5_stream_trait_consumption() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: line1\ndata: line2\n",
-            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("data: line1\ndata: line2\n"))
             .mount(&server)
             .await;
 
@@ -284,9 +281,9 @@ mod tests {
     async fn rs6_event_line_passthrough() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "event: message_start\ndata: hi\n\n",
-            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_string("event: message_start\ndata: hi\n\n"),
+            )
             .mount(&server)
             .await;
 

--- a/packages/catcher-http/src/transport/http_client.rs
+++ b/packages/catcher-http/src/transport/http_client.rs
@@ -1,21 +1,21 @@
 use reqwest::Client;
 use reqwest_middleware::{ClientBuilder as MiddlewareBuilder, ClientWithMiddleware};
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, RwLock};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
 use tokio::sync::Semaphore;
 
-use catcher_core::CatcherError;
+use crate::observability::metrics::{MetricsCollector, MetricsSnapshot};
 use crate::resilience::backoff::build_retry_policy;
 use crate::resilience::circuit_breaker::CircuitBreaker;
 use crate::resilience::timeout::AdaptiveTimeout;
 use crate::transport::retry_middleware::MetricsRetryMiddleware;
 use crate::transport::tls::build_tls_config;
 use crate::types::http::*;
-use crate::observability::metrics::{MetricsCollector, MetricsSnapshot};
 use catcher_core::types::resilience::CbState;
+use catcher_core::CatcherError;
 
 /// HTTP 传输层 — 真实收发 HTTP 请求，带重试中间件 + 熔断器 + 取消 + 自适应超时
 ///
@@ -92,7 +92,10 @@ impl HttpTransport {
                     Some(crate::scheduler::PriorityRequestQueue::new(queue_config)),
                 )
             } else {
-                (Some(Arc::new(Semaphore::new(config.max_concurrency as usize))), None)
+                (
+                    Some(Arc::new(Semaphore::new(config.max_concurrency as usize))),
+                    None,
+                )
             }
         } else {
             (None, None)
@@ -167,7 +170,9 @@ impl HttpTransport {
 fn build_middleware_client(
     config: &HttpClientConfig,
     metrics: &MetricsCollector,
-    #[cfg(feature = "hickory-dns")] dns_resolver: Option<&Arc<crate::transport::dns::ReqwestDnsResolver>>,
+    #[cfg(feature = "hickory-dns")] dns_resolver: Option<
+        &Arc<crate::transport::dns::ReqwestDnsResolver>,
+    >,
 ) -> Result<ClientWithMiddleware, CatcherError> {
     let mut reqwest_builder = Client::builder()
         .connect_timeout(Duration::from_millis(config.connect_timeout_ms))
@@ -200,7 +205,8 @@ fn build_middleware_client(
 
     // G4: Proxy configuration
     if let Some(ref proxy_config) = config.proxy {
-        let mut proxy = reqwest::Proxy::all(&proxy_config.url)
+        let proxy_url = proxy_config.transport_url();
+        let mut proxy = reqwest::Proxy::all(proxy_url.as_ref())
             .map_err(|e| CatcherError::InvalidConfig(format!("invalid proxy URL: {e}")))?;
         if let Some(ref auth) = proxy_config.auth {
             proxy = proxy.basic_auth(&auth.username, &auth.password);
@@ -217,7 +223,9 @@ fn build_middleware_client(
     // G6: Redirect policy
     reqwest_builder = match &config.redirect {
         Some(r) if !r.follow => reqwest_builder.redirect(reqwest::redirect::Policy::none()),
-        Some(r) => reqwest_builder.redirect(reqwest::redirect::Policy::limited(r.max_redirects as usize)),
+        Some(r) => {
+            reqwest_builder.redirect(reqwest::redirect::Policy::limited(r.max_redirects as usize))
+        }
         None => reqwest_builder,
     };
 
@@ -227,8 +235,9 @@ fn build_middleware_client(
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             "Authorization",
-            format!("Basic {}", encoded).parse()
-                .map_err(|e| CatcherError::InvalidConfig(format!("invalid basic auth header: {e}")))?,
+            format!("Basic {}", encoded).parse().map_err(|e| {
+                CatcherError::InvalidConfig(format!("invalid basic auth header: {e}"))
+            })?,
         );
         reqwest_builder = reqwest_builder.default_headers(headers);
     }
@@ -236,8 +245,9 @@ fn build_middleware_client(
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(
             "Authorization",
-            format!("Bearer {}", token).parse()
-                .map_err(|e| CatcherError::InvalidConfig(format!("invalid bearer token header: {e}")))?,
+            format!("Bearer {}", token).parse().map_err(|e| {
+                CatcherError::InvalidConfig(format!("invalid bearer token header: {e}"))
+            })?,
         );
         reqwest_builder = reqwest_builder.default_headers(headers);
     }
@@ -262,11 +272,13 @@ fn build_middleware_client(
 impl HttpTransport {
     /// 发起 HTTP 请求（带熔断器检查 + cancel 支持 + metrics 记录 + 自适应超时 + 并发控制）
     pub async fn execute(&self, request: HttpRequest) -> Result<HttpResponse, CatcherError> {
-        let (_, result) = self.execute_with_token(
-            0,  // dummy request_id, not registered for cancel
-            tokio_util::sync::CancellationToken::new(),  // uncancellable per-request token
-            request,
-        ).await;
+        let (_, result) = self
+            .execute_with_token(
+                0,                                          // dummy request_id, not registered for cancel
+                tokio_util::sync::CancellationToken::new(), // uncancellable per-request token
+                request,
+            )
+            .await;
         result
     }
 
@@ -285,7 +297,8 @@ impl HttpTransport {
         if let Some(ref cb) = self.circuit_breaker {
             if let Err(e) = cb.before_request() {
                 self.pending_requests.lock().unwrap().remove(&request_id);
-                self.metrics.record_http_request(false, start.elapsed().as_micros() as u64);
+                self.metrics
+                    .record_http_request(false, start.elapsed().as_micros() as u64);
                 return (request_id, Err(e));
             }
         }
@@ -416,8 +429,13 @@ impl HttpTransport {
         *token = tokio_util::sync::CancellationToken::new();
         drop(token);
         // Also cancel all per-request tokens (N-03)
-        let pending: Vec<tokio_util::sync::CancellationToken> =
-            self.pending_requests.lock().unwrap().drain().map(|(_, t)| t).collect();
+        let pending: Vec<tokio_util::sync::CancellationToken> = self
+            .pending_requests
+            .lock()
+            .unwrap()
+            .drain()
+            .map(|(_, t)| t)
+            .collect();
         for t in &pending {
             t.cancel();
         }
@@ -439,7 +457,10 @@ impl HttpTransport {
     pub fn allocate_pending_request(&self) -> (u64, tokio_util::sync::CancellationToken) {
         let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
         let token = tokio_util::sync::CancellationToken::new();
-        self.pending_requests.lock().unwrap().insert(request_id, token.clone());
+        self.pending_requests
+            .lock()
+            .unwrap()
+            .insert(request_id, token.clone());
         (request_id, token)
     }
 
@@ -449,8 +470,15 @@ impl HttpTransport {
     }
 
     /// 注册一个 per-request CancellationToken 供 cancel 使用（N-03）。
-    pub fn insert_pending_request(&self, request_id: u64, token: tokio_util::sync::CancellationToken) {
-        self.pending_requests.lock().unwrap().insert(request_id, token);
+    pub fn insert_pending_request(
+        &self,
+        request_id: u64,
+        token: tokio_util::sync::CancellationToken,
+    ) {
+        self.pending_requests
+            .lock()
+            .unwrap()
+            .insert(request_id, token);
     }
 
     /// 清理已完成的请求（N-03）。
@@ -485,23 +513,37 @@ impl HttpTransport {
         let url = if request.url.starts_with("http") {
             request.url
         } else {
-            format!("{}{}", self.config.base_url.trim_end_matches('/'), request.url)
+            format!(
+                "{}{}",
+                self.config.base_url.trim_end_matches('/'),
+                request.url
+            )
         };
 
         let client = self.client();
         let mut req = client.request(method, &url);
-        for (k, v) in &self.config.default_headers { req = req.header(k, v); }
-        for (k, v) in &request.headers { req = req.header(k, v); }
+        for (k, v) in &self.config.default_headers {
+            req = req.header(k, v);
+        }
+        for (k, v) in &request.headers {
+            req = req.header(k, v);
+        }
         // B-02: multipart support
         if let Some(ref form) = request.multipart {
             let (encoded_body, ct) = form.encode();
             req = req.body(encoded_body);
             req = req.header("Content-Type", ct);
         } else {
-            if let Some(body) = &request.body { req = req.body(body.clone()); }
-            if let Some(ct) = &request.content_type { req = req.header("Content-Type", ct); }
+            if let Some(body) = &request.body {
+                req = req.body(body.clone());
+            }
+            if let Some(ct) = &request.content_type {
+                req = req.header("Content-Type", ct);
+            }
         }
-        let timeout_ms = request.timeout_ms.unwrap_or(self.config.response_timeout_ms);
+        let timeout_ms = request
+            .timeout_ms
+            .unwrap_or(self.config.response_timeout_ms);
         req = req.timeout(Duration::from_millis(timeout_ms));
 
         let global_token = {
@@ -522,7 +564,9 @@ impl HttpTransport {
         };
 
         let status = response.status().as_u16();
-        let headers: HashMap<String, String> = response.headers().iter()
+        let headers: HashMap<String, String> = response
+            .headers()
+            .iter()
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
             .collect();
 
@@ -623,7 +667,12 @@ impl HttpTransport {
         window_size: usize,
     ) {
         let mut at = self.adaptive_timeout.lock().unwrap();
-        *at = Some(AdaptiveTimeout::new(min_timeout_ms, max_timeout_ms, multiplier, window_size));
+        *at = Some(AdaptiveTimeout::new(
+            min_timeout_ms,
+            max_timeout_ms,
+            multiplier,
+            window_size,
+        ));
     }
 
     pub fn disable_adaptive_timeout(&self) {
@@ -652,11 +701,7 @@ async fn execute_http_request(
     let url = if request.url.starts_with("http") {
         request.url
     } else {
-        format!(
-            "{}{}",
-            config.base_url.trim_end_matches('/'),
-            request.url,
-        )
+        format!("{}{}", config.base_url.trim_end_matches('/'), request.url,)
     };
 
     // G7: host_mapping is handled by the shared DNS resolver.
@@ -678,8 +723,9 @@ async fn execute_http_request(
     } else if config.msgpack {
         // msgpack: encode JSON body → msgpack binary
         if let Some(body) = &request.body {
-            let value: serde_json::Value = serde_json::from_slice(body)
-                .map_err(|e| CatcherError::Internal(format!("msgpack encode: invalid JSON body: {e}")))?;
+            let value: serde_json::Value = serde_json::from_slice(body).map_err(|e| {
+                CatcherError::Internal(format!("msgpack encode: invalid JSON body: {e}"))
+            })?;
             let encoded = rmp_serde::to_vec(&value)
                 .map_err(|e| CatcherError::Internal(format!("msgpack encode: {e}")))?;
             req = req.body(encoded);
@@ -699,9 +745,7 @@ async fn execute_http_request(
         req = req.header("Host", override_host.as_str());
     }
 
-    let timeout_ms = request
-        .timeout_ms
-        .unwrap_or(config.response_timeout_ms);
+    let timeout_ms = request.timeout_ms.unwrap_or(config.response_timeout_ms);
     req = req.timeout(Duration::from_millis(timeout_ms));
 
     let response = req
@@ -746,8 +790,9 @@ async fn execute_http_request(
                     body.len(),
                 )));
             }
-            serde_json::to_vec(&value)
-                .map_err(|e| CatcherError::Internal(format!("msgpack decode: json serialize: {e}")))?
+            serde_json::to_vec(&value).map_err(|e| {
+                CatcherError::Internal(format!("msgpack decode: json serialize: {e}"))
+            })?
         } else {
             body.to_vec()
         }
@@ -763,7 +808,10 @@ async fn execute_http_request(
     })
 }
 
-fn map_middleware_error_standalone(e: reqwest_middleware::Error, config: &HttpClientConfig) -> CatcherError {
+fn map_middleware_error_standalone(
+    e: reqwest_middleware::Error,
+    config: &HttpClientConfig,
+) -> CatcherError {
     let msg = format!("{e}");
     if msg.contains("timeout") || msg.contains("timed out") {
         return CatcherError::RequestTimeout(config.response_timeout_ms);
@@ -803,8 +851,8 @@ mod tests {
 
     #[tokio::test]
     async fn re1_http_error_carries_request_info() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -844,8 +892,8 @@ mod tests {
 
     #[tokio::test]
     async fn rp2_no_proxy_direct_connection() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -866,8 +914,8 @@ mod tests {
 
     #[tokio::test]
     async fn rrd1_follow_redirect() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -893,8 +941,8 @@ mod tests {
 
     #[tokio::test]
     async fn rrd2_disable_redirect() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -905,7 +953,10 @@ mod tests {
 
         let config = HttpClientConfig {
             base_url: server.uri(),
-            redirect: Some(RedirectConfig { follow: false, max_redirects: 0 }),
+            redirect: Some(RedirectConfig {
+                follow: false,
+                max_redirects: 0,
+            }),
             ..Default::default()
         };
         let transport = HttpTransport::new(config).unwrap();
@@ -946,8 +997,8 @@ mod tests {
     /// network_changed() 重建客户端后，新请求应正常工作
     #[tokio::test]
     async fn network_changed_rebuilds_client_and_requests_work() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -1000,72 +1051,124 @@ mod tests {
 
     #[tokio::test]
     async fn ns02_stream_receives_body_via_callback() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
-        use wiremock::matchers::method;
         use crate::types::http::StreamEvent;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .respond_with(ResponseTemplate::new(200).set_body_string("hello world"))
-            .mount(&server).await;
-        let config = HttpClientConfig { base_url: server.uri(), ..Default::default() };
+            .mount(&server)
+            .await;
+        let config = HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        };
         let transport = HttpTransport::new(config).unwrap();
         let events = Arc::new(Mutex::new(Vec::<StreamEvent>::new()));
         let ec = events.clone();
         let request = HttpRequest {
-            method: HttpMethod::GET, url: "/test".to_string(),
-            headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+            method: HttpMethod::GET,
+            url: "/test".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            content_type: None,
+            timeout_ms: None,
             ..Default::default()
         };
-        transport.execute_stream(request, tokio_util::sync::CancellationToken::new(), move |e| { ec.lock().unwrap().push(e); }).await.unwrap();
+        transport
+            .execute_stream(
+                request,
+                tokio_util::sync::CancellationToken::new(),
+                move |e| {
+                    ec.lock().unwrap().push(e);
+                },
+            )
+            .await
+            .unwrap();
         let evts = events.lock().unwrap();
         assert!(evts.len() >= 3);
         assert!(matches!(&evts[0], StreamEvent::Headers { status: 200, .. }));
         assert!(matches!(evts.last(), Some(StreamEvent::Done)));
-        let body: Vec<u8> = evts.iter().filter_map(|e| match e {
-            StreamEvent::Chunk(d) => Some(d.as_ref()), _ => None,
-        }).flatten().copied().collect();
+        let body: Vec<u8> = evts
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::Chunk(d) => Some(d.as_ref()),
+                _ => None,
+            })
+            .flatten()
+            .copied()
+            .collect();
         assert_eq!(String::from_utf8(body).unwrap(), "hello world");
     }
 
     #[tokio::test]
     async fn ns02_stream_empty_body() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
-        use wiremock::matchers::method;
         use crate::types::http::StreamEvent;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
-        Mock::given(method("GET")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
-        let config = HttpClientConfig { base_url: server.uri(), ..Default::default() };
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let config = HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        };
         let transport = HttpTransport::new(config).unwrap();
         let events = Arc::new(Mutex::new(Vec::<StreamEvent>::new()));
         let ec = events.clone();
         let request = HttpRequest {
-            method: HttpMethod::GET, url: "/test".to_string(),
-            headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+            method: HttpMethod::GET,
+            url: "/test".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            content_type: None,
+            timeout_ms: None,
             ..Default::default()
         };
-        transport.execute_stream(request, tokio_util::sync::CancellationToken::new(), move |e| { ec.lock().unwrap().push(e); }).await.unwrap();
+        transport
+            .execute_stream(
+                request,
+                tokio_util::sync::CancellationToken::new(),
+                move |e| {
+                    ec.lock().unwrap().push(e);
+                },
+            )
+            .await
+            .unwrap();
         let evts = events.lock().unwrap();
-        assert_eq!(evts.iter().filter(|e| matches!(e, StreamEvent::Chunk(_))).count(), 0);
+        assert_eq!(
+            evts.iter()
+                .filter(|e| matches!(e, StreamEvent::Chunk(_)))
+                .count(),
+            0
+        );
         assert!(matches!(&evts[0], StreamEvent::Headers { .. }));
         assert!(matches!(evts.last(), Some(StreamEvent::Done)));
     }
 
     #[tokio::test]
     async fn ns02_stream_cancel_interrupts() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
-        use wiremock::matchers::method;
         use crate::types::http::StreamEvent;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
-            .respond_with(ResponseTemplate::new(200)
-                .set_body_string("x".repeat(65536))
-                .set_delay(std::time::Duration::from_secs(30)))
-            .mount(&server).await;
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("x".repeat(65536))
+                    .set_delay(std::time::Duration::from_secs(30)),
+            )
+            .mount(&server)
+            .await;
         let config = HttpClientConfig {
-            base_url: server.uri(), response_timeout_ms: 60000, ..Default::default()
+            base_url: server.uri(),
+            response_timeout_ms: 60000,
+            ..Default::default()
         };
         let transport = Arc::new(HttpTransport::new(config).unwrap());
         let events = Arc::new(Mutex::new(Vec::<StreamEvent>::new()));
@@ -1076,50 +1179,83 @@ mod tests {
             ct.cancel_all();
         });
         let request = HttpRequest {
-            method: HttpMethod::GET, url: "/test".to_string(),
-            headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+            method: HttpMethod::GET,
+            url: "/test".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            content_type: None,
+            timeout_ms: None,
             ..Default::default()
         };
-        let result = transport.execute_stream(request, tokio_util::sync::CancellationToken::new(), move |e| { ec.lock().unwrap().push(e); }).await;
+        let result = transport
+            .execute_stream(
+                request,
+                tokio_util::sync::CancellationToken::new(),
+                move |e| {
+                    ec.lock().unwrap().push(e);
+                },
+            )
+            .await;
         assert!(result.is_err());
-        assert!(events.lock().unwrap().iter().any(|e| matches!(e, StreamEvent::Error(m) if m.contains("cancelled"))));
+        assert!(events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|e| matches!(e, StreamEvent::Error(m) if m.contains("cancelled"))));
     }
 
     #[tokio::test]
     async fn ns02_stream_connection_error() {
         let config = HttpClientConfig {
             base_url: "http://127.0.0.1:1".to_string(),
-            connect_timeout_ms: 500, response_timeout_ms: 500, ..Default::default()
+            connect_timeout_ms: 500,
+            response_timeout_ms: 500,
+            ..Default::default()
         };
         let transport = HttpTransport::new(config).unwrap();
         let request = HttpRequest {
-            method: HttpMethod::GET, url: "/test".to_string(),
-            headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+            method: HttpMethod::GET,
+            url: "/test".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            content_type: None,
+            timeout_ms: None,
             ..Default::default()
         };
-        assert!(transport.execute_stream(request, tokio_util::sync::CancellationToken::new(), |_| {}).await.is_err());
+        assert!(transport
+            .execute_stream(request, tokio_util::sync::CancellationToken::new(), |_| {})
+            .await
+            .is_err());
     }
 
     // ── N-03: Per-request cancel tests ──
 
     #[tokio::test]
     async fn ns03_execute_returns_unique_ids() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
-            .mount(&server).await;
-        let config = HttpClientConfig { base_url: server.uri(), ..Default::default() };
+            .mount(&server)
+            .await;
+        let config = HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        };
         let transport = Arc::new(HttpTransport::new(config).unwrap());
         let mut ids = Vec::new();
         for _ in 0..3 {
             let (rid, token) = transport.allocate_pending_request();
             let t = transport.clone();
             let request = HttpRequest {
-                method: HttpMethod::GET, url: "/test".to_string(),
-                headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+                method: HttpMethod::GET,
+                url: "/test".to_string(),
+                headers: HashMap::new(),
+                body: None,
+                content_type: None,
+                timeout_ms: None,
                 ..Default::default()
             };
             let (returned_id, result) = t.execute_with_token(rid, token, request).await;
@@ -1127,7 +1263,9 @@ mod tests {
             ids.push(returned_id);
         }
         assert_eq!(ids.len(), 3);
-        for i in 1..ids.len() { assert!(ids[i] > ids[i - 1]); }
+        for i in 1..ids.len() {
+            assert!(ids[i] > ids[i - 1]);
+        }
     }
 
     #[tokio::test]
@@ -1139,15 +1277,18 @@ mod tests {
 
     #[tokio::test]
     async fn ns03_cancel_all_cancels_everything() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(30)))
-            .mount(&server).await;
+            .mount(&server)
+            .await;
         let config = HttpClientConfig {
-            base_url: server.uri(), response_timeout_ms: 60000, ..Default::default()
+            base_url: server.uri(),
+            response_timeout_ms: 60000,
+            ..Default::default()
         };
         let transport = Arc::new(HttpTransport::new(config).unwrap());
         let mut handles = Vec::new();
@@ -1155,11 +1296,17 @@ mod tests {
             let (rid, token) = transport.allocate_pending_request();
             let t = transport.clone();
             let request = HttpRequest {
-                method: HttpMethod::GET, url: "/test".to_string(),
-                headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+                method: HttpMethod::GET,
+                url: "/test".to_string(),
+                headers: HashMap::new(),
+                body: None,
+                content_type: None,
+                timeout_ms: None,
                 ..Default::default()
             };
-            handles.push(tokio::spawn(async move { t.execute_with_token(rid, token, request).await }));
+            handles.push(tokio::spawn(async move {
+                t.execute_with_token(rid, token, request).await
+            }));
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         transport.cancel_all();
@@ -1171,19 +1318,27 @@ mod tests {
 
     #[tokio::test]
     async fn ns03_cancel_all_then_new_requests_work() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
-            .mount(&server).await;
-        let config = HttpClientConfig { base_url: server.uri(), ..Default::default() };
+            .mount(&server)
+            .await;
+        let config = HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        };
         let transport = HttpTransport::new(config).unwrap();
         transport.cancel_all();
         let request = HttpRequest {
-            method: HttpMethod::GET, url: "/test".to_string(),
-            headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+            method: HttpMethod::GET,
+            url: "/test".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            content_type: None,
+            timeout_ms: None,
             ..Default::default()
         };
         assert!(transport.execute(request).await.is_ok());
@@ -1191,23 +1346,34 @@ mod tests {
 
     #[tokio::test]
     async fn ns03_cancel_idempotent() {
-        use wiremock::{MockServer, Mock, ResponseTemplate};
         use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
-            .mount(&server).await;
-        let config = HttpClientConfig { base_url: server.uri(), ..Default::default() };
+            .mount(&server)
+            .await;
+        let config = HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        };
         let transport = HttpTransport::new(config).unwrap();
         let (rid, token) = transport.allocate_pending_request();
         let request = HttpRequest {
-            method: HttpMethod::GET, url: "/test".to_string(),
-            headers: HashMap::new(), body: None, content_type: None, timeout_ms: None,
+            method: HttpMethod::GET,
+            url: "/test".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            content_type: None,
+            timeout_ms: None,
             ..Default::default()
         };
         let (_, result) = transport.execute_with_token(rid, token, request).await;
         assert!(result.is_ok());
-        assert!(!transport.cancel_request(rid), "completed request should not be cancellable");
+        assert!(
+            !transport.cancel_request(rid),
+            "completed request should not be cancellable"
+        );
     }
 }

--- a/packages/catcher-http/src/transport/multipart.rs
+++ b/packages/catcher-http/src/transport/multipart.rs
@@ -13,10 +13,7 @@ use std::fmt;
 #[derive(Debug, Clone)]
 pub enum Part {
     /// A text form field.
-    Text {
-        name: String,
-        value: String,
-    },
+    Text { name: String, value: String },
     /// A binary file field.
     File {
         name: String,
@@ -229,9 +226,12 @@ mod tests {
 
     #[test]
     fn mp2_file_upload() {
-        let form = MultipartForm::new()
-            .text("description", "my avatar")
-            .file("avatar", "photo.png", "image/png", vec![0x89, 0x50, 0x4E, 0x47]);
+        let form = MultipartForm::new().text("description", "my avatar").file(
+            "avatar",
+            "photo.png",
+            "image/png",
+            vec![0x89, 0x50, 0x4E, 0x47],
+        );
 
         let (body, ct) = form.encode();
         let body_str = String::from_utf8_lossy(&body);
@@ -244,8 +244,11 @@ mod tests {
 
     #[test]
     fn mp3_bytes_field() {
-        let form = MultipartForm::new()
-            .bytes("binary_data", "application/octet-stream", vec![0x00, 0x01, 0x02]);
+        let form = MultipartForm::new().bytes(
+            "binary_data",
+            "application/octet-stream",
+            vec![0x00, 0x01, 0x02],
+        );
 
         let (body, _ct) = form.encode();
         assert!(!body.is_empty());

--- a/packages/catcher-http/src/transport/retry_middleware.rs
+++ b/packages/catcher-http/src/transport/retry_middleware.rs
@@ -2,16 +2,14 @@
 //!
 //! Replaces `reqwest_retry::RetryTransientMiddleware` which has no callback mechanism.
 
-use std::sync::Weak;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Weak;
 use std::time::{Duration, SystemTime};
 
 use http::Extensions;
 use reqwest::{Request, Response};
 use reqwest_middleware::{Error, Middleware, Next, Result};
-use reqwest_retry::{
-    DefaultRetryableStrategy, Retryable, RetryableStrategy, RetryError,
-};
+use reqwest_retry::{DefaultRetryableStrategy, RetryError, Retryable, RetryableStrategy};
 use retry_policies::RetryPolicy;
 
 /// Retry middleware that notifies `MetricsCollector` on each retry attempt.
@@ -71,9 +69,9 @@ where
         let start_time = SystemTime::now();
 
         loop {
-            let duplicate_request = req.try_clone().ok_or_else(|| {
-                Error::middleware(NoCloneError)
-            })?;
+            let duplicate_request = req
+                .try_clone()
+                .ok_or_else(|| Error::middleware(NoCloneError))?;
 
             let result = next.clone().run(duplicate_request, ext).await;
 
@@ -120,7 +118,10 @@ struct NoCloneError;
 
 impl std::fmt::Display for NoCloneError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Request object is not cloneable. Are you passing a streaming body?")
+        write!(
+            f,
+            "Request object is not cloneable. Are you passing a streaming body?"
+        )
     }
 }
 

--- a/packages/catcher-http/src/transport/tls.rs
+++ b/packages/catcher-http/src/transport/tls.rs
@@ -1,5 +1,5 @@
-use catcher_core::CatcherError;
 use crate::types::http::TlsConfig;
+use catcher_core::CatcherError;
 use reqwest::ClientBuilder;
 
 /// 将 TlsConfig 应用到 reqwest ClientBuilder
@@ -13,7 +13,11 @@ pub fn build_tls_config(
 ) -> Result<ClientBuilder, CatcherError> {
     // If pin_sha256 is set, build a full rustls::ClientConfig with pinning verifier
     #[cfg(feature = "rustls-tls")]
-    if config.pin_sha256.as_ref().is_some_and(|pins| !pins.is_empty()) {
+    if config
+        .pin_sha256
+        .as_ref()
+        .is_some_and(|pins| !pins.is_empty())
+    {
         return build_tls_with_pinning(builder, config);
     }
 
@@ -58,8 +62,9 @@ pub fn build_tls_config(
         let key_pem = std::fs::read_to_string(key_path)
             .map_err(|e| CatcherError::TlsError(format!("read client key {}: {e}", key_path)))?;
         let identity_pem = format!("{cert_pem}\n{key_pem}");
-        let identity = reqwest::Identity::from_pem(identity_pem.as_bytes())
-            .map_err(|e| CatcherError::TlsError(format!("parse client identity from files: {e}")))?;
+        let identity = reqwest::Identity::from_pem(identity_pem.as_bytes()).map_err(|e| {
+            CatcherError::TlsError(format!("parse client identity from files: {e}"))
+        })?;
         builder = builder.identity(identity);
     }
 
@@ -109,9 +114,9 @@ fn build_tls_with_pinning(
     builder: ClientBuilder,
     config: &TlsConfig,
 ) -> Result<ClientBuilder, CatcherError> {
-    use std::sync::Arc;
-    use rustls_pki_types::pem::PemObject;
     use crate::transport::tls_pinning::PinningVerifier;
+    use rustls_pki_types::pem::PemObject;
+    use std::sync::Arc;
 
     // Build root certificate store
     let mut root_store = rustls::RootCertStore::empty();
@@ -123,7 +128,8 @@ fn build_tls_with_pinning(
     if let Some(ref pem) = config.ca_cert_pem {
         for cert in rustls_pki_types::CertificateDer::pem_slice_iter(pem.as_bytes()) {
             let cert = cert.map_err(|e| CatcherError::TlsError(format!("parse PEM cert: {e}")))?;
-            root_store.add(cert)
+            root_store
+                .add(cert)
                 .map_err(|e| CatcherError::TlsError(format!("add CA cert: {e}")))?;
         }
     }
@@ -134,7 +140,8 @@ fn build_tls_with_pinning(
             .map_err(|e| CatcherError::TlsError(format!("read CA cert file {}: {e}", path)))?;
         for cert in rustls_pki_types::CertificateDer::pem_slice_iter(&pem_bytes) {
             let cert = cert.map_err(|e| CatcherError::TlsError(format!("parse PEM cert: {e}")))?;
-            root_store.add(cert)
+            root_store
+                .add(cert)
                 .map_err(|e| CatcherError::TlsError(format!("add CA cert from file: {e}")))?;
         }
     }
@@ -192,7 +199,8 @@ mod tests {
 
     #[test]
     fn tls3_config_with_ca_cert_pem_invalid() {
-        let invalid_pem = "-----BEGIN CERTIFICATE-----\nnot-a-real-cert\n-----END CERTIFICATE-----\n";
+        let invalid_pem =
+            "-----BEGIN CERTIFICATE-----\nnot-a-real-cert\n-----END CERTIFICATE-----\n";
         let config = TlsConfig {
             ca_cert_pem: Some(invalid_pem.to_string()),
             ..Default::default()

--- a/packages/catcher-http/src/transport/tls_pinning.rs
+++ b/packages/catcher-http/src/transport/tls_pinning.rs
@@ -4,12 +4,12 @@
 //! the SHA-256 hash of the end-entity certificate's DER bytes must match
 //! one of the configured pins.
 
-use std::sync::Arc;
-use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerifier, ServerCertVerified};
-use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
-use rustls::{Error as TlsError, SignatureScheme, DigitallySignedStruct};
-use sha2::{Digest, Sha256};
 use base64::Engine;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, Error as TlsError, SignatureScheme};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
 
 /// A certificate verifier that enforces SHA-256 pinning on top of normal validation.
 #[derive(Debug)]
@@ -134,7 +134,10 @@ mod tests {
 
     #[test]
     fn pin2_ignore_invalid_pins() {
-        let v = PinningVerifier::new(make_mock_verifier(), &["not-base64!!!".to_string(), "AAAA".to_string()]);
+        let v = PinningVerifier::new(
+            make_mock_verifier(),
+            &["not-base64!!!".to_string(), "AAAA".to_string()],
+        );
         assert_eq!(v.pins.len(), 0);
     }
 }

--- a/packages/catcher-http/src/types/http.rs
+++ b/packages/catcher-http/src/types/http.rs
@@ -1,7 +1,7 @@
 use catcher_core::types::default_true;
 pub use catcher_core::types::network::{ProxyAuth, ProxyConfig, TlsConfig, TlsVersion};
 use catcher_core::types::resilience::{CircuitBreakerConfig, RetryConfig};
-pub use catcher_dns::DnsConfig;
+pub use catcher_dns::{DnsConfig, DnsMode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/packages/catcher-http/tests/local_proxy_test.rs
+++ b/packages/catcher-http/tests/local_proxy_test.rs
@@ -50,3 +50,11 @@ async fn local_socks5h_proxy_reaches_https_endpoint() {
         .unwrap_or_else(|_| "socks5h://127.0.0.1:7890".to_string());
     assert_http_via_proxy(proxy_url).await;
 }
+
+#[tokio::test]
+#[ignore = "requires a local SOCKS proxy, for example CATCHER_TEST_SOCKS5_PROXY=socks5://127.0.0.1:7890"]
+async fn local_socks5_proxy_reaches_https_endpoint() {
+    let proxy_url = std::env::var("CATCHER_TEST_SOCKS5_PROXY")
+        .unwrap_or_else(|_| "socks5://127.0.0.1:7890".to_string());
+    assert_http_via_proxy(proxy_url).await;
+}

--- a/packages/catcher-http/tests/proxy_dns_behavior_test.rs
+++ b/packages/catcher-http/tests/proxy_dns_behavior_test.rs
@@ -1,0 +1,152 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::time::Duration;
+
+use catcher_http::types::http::{
+    DnsConfig, DnsMode, HttpClientConfig, HttpMethod, HttpRequest, ProxyConfig,
+};
+use catcher_http::HttpTransport;
+use catcher_test_support::http_proxy::{HttpProxyProbe, HttpProxyRequest};
+use catcher_test_support::socks5::{Socks5Address, Socks5Probe};
+
+fn proxy_config(url: String) -> ProxyConfig {
+    ProxyConfig {
+        url,
+        auth: None,
+        no_proxy: Vec::new(),
+    }
+}
+
+fn proxy_config_with_no_proxy(url: String, no_proxy: Vec<String>) -> ProxyConfig {
+    ProxyConfig {
+        url,
+        auth: None,
+        no_proxy,
+    }
+}
+
+fn catcher_dns_mapping() -> DnsConfig {
+    DnsConfig {
+        mode: DnsMode::Catcher,
+        host_mapping: HashMap::from([("example.com".to_string(), "127.0.0.1".to_string())]),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn socks5_proxy_receives_domain_even_when_catcher_dns_is_enabled(
+) -> Result<(), Box<dyn Error>> {
+    let mut proxy = Socks5Probe::start().await?;
+    let transport = HttpTransport::new(HttpClientConfig {
+        proxy: Some(proxy_config(proxy.socks5_url())),
+        dns: Some(catcher_dns_mapping()),
+        connect_timeout_ms: 1_000,
+        response_timeout_ms: 2_000,
+        max_concurrency: 0,
+        ..Default::default()
+    })?;
+
+    let request_task = tokio::spawn(async move {
+        transport
+            .execute(HttpRequest {
+                method: HttpMethod::GET,
+                url: "http://example.com/proxy-check".to_string(),
+                timeout_ms: Some(2_000),
+                ..Default::default()
+            })
+            .await
+    });
+
+    let connect = proxy.wait_for_connect().await?;
+    assert_eq!(
+        connect.address,
+        Socks5Address::Domain("example.com".to_string())
+    );
+    assert_eq!(connect.port, 80);
+
+    let response = request_task.await??;
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, b"ok");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn http_no_proxy_bypasses_configured_proxy() -> Result<(), Box<dyn Error>> {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let mut proxy = HttpProxyProbe::start().await?;
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("direct"))
+        .mount(&server)
+        .await;
+
+    let transport = HttpTransport::new(HttpClientConfig {
+        proxy: Some(proxy_config_with_no_proxy(
+            proxy.http_url(),
+            vec!["127.0.0.1".to_string()],
+        )),
+        connect_timeout_ms: 1_000,
+        response_timeout_ms: 2_000,
+        max_concurrency: 0,
+        ..Default::default()
+    })?;
+
+    let response = transport
+        .execute(HttpRequest {
+            method: HttpMethod::GET,
+            url: server.uri(),
+            timeout_ms: Some(2_000),
+            ..Default::default()
+        })
+        .await?;
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, b"direct");
+    proxy.assert_no_request(Duration::from_millis(200)).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn http_proxy_connect_receives_domain_even_when_catcher_dns_is_enabled(
+) -> Result<(), Box<dyn Error>> {
+    let mut proxy = HttpProxyProbe::start().await?;
+    let transport = HttpTransport::new(HttpClientConfig {
+        proxy: Some(proxy_config(proxy.http_url())),
+        dns: Some(catcher_dns_mapping()),
+        connect_timeout_ms: 1_000,
+        response_timeout_ms: 2_000,
+        max_concurrency: 0,
+        ..Default::default()
+    })?;
+
+    let request_task = tokio::spawn(async move {
+        transport
+            .execute(HttpRequest {
+                method: HttpMethod::GET,
+                url: "https://example.com/connect-check".to_string(),
+                timeout_ms: Some(2_000),
+                ..Default::default()
+            })
+            .await
+    });
+
+    let request = proxy.wait_for_request().await?;
+    assert_eq!(
+        request,
+        HttpProxyRequest::Connect {
+            authority: "example.com:443".to_string()
+        }
+    );
+
+    let response_result = request_task.await?;
+    assert!(
+        response_result.is_err(),
+        "fake HTTP proxy closes after CONNECT, so TLS should fail"
+    );
+
+    Ok(())
+}

--- a/packages/catcher-napi-http/README.md
+++ b/packages/catcher-napi-http/README.md
@@ -53,6 +53,7 @@ const client = new HttpClient({
   retry: { max_attempts: 3, backoff: 'Fixed' },
   circuit_breaker: { failure_threshold: 5, reset_timeout_ms: 30000 },
   dns: {
+    mode: 'catcher',
     cache_size: 512,
     cache_ttl_secs: 300,
     negative_ttl_secs: 60,
@@ -127,6 +128,7 @@ interface HttpClientConfig {
 }
 
 interface DnsConfig {
+  mode?: 'catcher' | 'native'        // default: 'catcher'
   cache_size?: number                // default: 512
   cache_ttl_secs?: number            // default: 300
   negative_ttl_secs?: number         // default: 60

--- a/packages/catcher-napi-http/src/client.rs
+++ b/packages/catcher-napi-http/src/client.rs
@@ -12,11 +12,9 @@
 //! }
 //! ```
 
-use napi::*;
 use napi::bindgen_prelude::Buffer;
-use napi::threadsafe_function::{
-    ThreadSafeCallContext, ThreadsafeFunctionCallMode,
-};
+use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
+use napi::*;
 use napi_derive::napi;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -140,7 +138,8 @@ impl JsHttpClient {
         url: String,
         options: Option<RequestOptions>,
     ) -> napi::Result<JsHttpResponse> {
-        self.do_execute(HttpMethod::DELETE, url, None, options).await
+        self.do_execute(HttpMethod::DELETE, url, None, options)
+            .await
     }
 
     /// PATCH request
@@ -282,13 +281,14 @@ impl JsHttpClient {
         let inner = self.inner.clone();
         tokio::spawn(async move {
             let _ = inner
-                .execute_stream(request, tokio_util::sync::CancellationToken::new(), move |event| {
-                    let json = stream_event_to_json(&event);
-                    let _ = tsfn.call(
-                        Ok(json),
-                        ThreadsafeFunctionCallMode::NonBlocking,
-                    );
-                })
+                .execute_stream(
+                    request,
+                    tokio_util::sync::CancellationToken::new(),
+                    move |event| {
+                        let json = stream_event_to_json(&event);
+                        let _ = tsfn.call(Ok(json), ThreadsafeFunctionCallMode::NonBlocking);
+                    },
+                )
                 .await;
         });
 

--- a/packages/catcher-napi-http/src/helpers.rs
+++ b/packages/catcher-napi-http/src/helpers.rs
@@ -1,5 +1,5 @@
-use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
 use catcher_http::types::http::{HttpMethod, StreamEvent};
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
 
 pub(crate) type Tsfn = ThreadsafeFunction<String, ErrorStrategy::CalleeHandled>;
 

--- a/packages/catcher-napi-http/src/sse.rs
+++ b/packages/catcher-napi-http/src/sse.rs
@@ -1,12 +1,10 @@
+use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode};
 use napi::*;
-use napi::threadsafe_function::{
-    ThreadSafeCallContext, ThreadsafeFunctionCallMode,
-};
 use napi_derive::napi;
 use serde::{Deserialize, Serialize};
 
-use catcher_http::{SseClient, SseStream};
 use catcher_core::types::sse::SseClientConfig;
+use catcher_http::{SseClient, SseStream};
 
 use crate::helpers::Tsfn;
 
@@ -56,13 +54,11 @@ pub fn sse_stream(
     config_json: String,
     #[napi(ts_arg_type = "(eventJson: string) => void")] on_event: JsFunction,
 ) -> napi::Result<JsSseStream> {
-    let config: SseClientConfig = serde_json::from_str(&config_json)
-        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    let config: SseClientConfig =
+        serde_json::from_str(&config_json).map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
     let tsfn: Tsfn = on_event
-        .create_threadsafe_function(0, |ctx: ThreadSafeCallContext<String>| {
-            Ok(vec![ctx.value])
-        })?;
+        .create_threadsafe_function(0, |ctx: ThreadSafeCallContext<String>| Ok(vec![ctx.value]))?;
 
     let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
@@ -92,10 +88,7 @@ pub fn sse_stream(
                         _ = cancel_rx.recv() => break,
                     }
                 }
-                let _ = tsfn.call(
-                    Ok(sse_end_json()),
-                    ThreadsafeFunctionCallMode::NonBlocking,
-                );
+                let _ = tsfn.call(Ok(sse_end_json()), ThreadsafeFunctionCallMode::NonBlocking);
             }
             Err(e) => {
                 let _ = tsfn.call(
@@ -117,13 +110,11 @@ pub fn sse_client(
     config_json: String,
     #[napi(ts_arg_type = "(eventJson: string) => void")] on_event: JsFunction,
 ) -> napi::Result<JsSseClient> {
-    let config: SseClientConfig = serde_json::from_str(&config_json)
-        .map_err(|e| napi::Error::from_reason(e.to_string()))?;
+    let config: SseClientConfig =
+        serde_json::from_str(&config_json).map_err(|e| napi::Error::from_reason(e.to_string()))?;
 
     let tsfn: Tsfn = on_event
-        .create_threadsafe_function(0, |ctx: ThreadSafeCallContext<String>| {
-            Ok(vec![ctx.value])
-        })?;
+        .create_threadsafe_function(0, |ctx: ThreadSafeCallContext<String>| Ok(vec![ctx.value]))?;
 
     let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
@@ -155,10 +146,7 @@ pub fn sse_client(
                         }
                     }
                 }
-                let _ = tsfn.call(
-                    Ok(sse_end_json()),
-                    ThreadsafeFunctionCallMode::NonBlocking,
-                );
+                let _ = tsfn.call(Ok(sse_end_json()), ThreadsafeFunctionCallMode::NonBlocking);
             }
             Err(e) => {
                 let _ = tsfn.call(
@@ -186,11 +174,17 @@ pub(crate) enum SseEvent {
 }
 
 pub(crate) fn sse_line_json(line: &str) -> String {
-    serde_json::to_string(&SseEvent::Line { data: line.to_owned() }).unwrap_or_default()
+    serde_json::to_string(&SseEvent::Line {
+        data: line.to_owned(),
+    })
+    .unwrap_or_default()
 }
 
 pub(crate) fn sse_error_json(msg: &str) -> String {
-    serde_json::to_string(&SseEvent::Error { message: msg.to_owned() }).unwrap_or_default()
+    serde_json::to_string(&SseEvent::Error {
+        message: msg.to_owned(),
+    })
+    .unwrap_or_default()
 }
 
 pub(crate) fn sse_end_json() -> String {

--- a/packages/catcher-napi-http/src/tests.rs
+++ b/packages/catcher-napi-http/src/tests.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
+use catcher_core::types::sse::SseClientConfig;
 use catcher_http::{
     types::http::{HttpClientConfig, HttpMethod, StreamEvent},
     HttpTransport, MetricsSnapshot,
 };
-use catcher_core::types::sse::SseClientConfig;
 
 use super::client::JsMetrics;
 use super::helpers::{parse_method, stream_event_to_json};
@@ -17,7 +17,10 @@ fn parse_method_all() {
     assert!(matches!(parse_method("get").unwrap(), HttpMethod::GET));
     assert!(matches!(parse_method("POST").unwrap(), HttpMethod::POST));
     assert!(matches!(parse_method("PUT").unwrap(), HttpMethod::PUT));
-    assert!(matches!(parse_method("DELETE").unwrap(), HttpMethod::DELETE));
+    assert!(matches!(
+        parse_method("DELETE").unwrap(),
+        HttpMethod::DELETE
+    ));
     assert!(matches!(parse_method("PATCH").unwrap(), HttpMethod::PATCH));
     assert!(parse_method("INVALID").is_err());
 }

--- a/packages/catcher-napi-http/ts/types.ts
+++ b/packages/catcher-napi-http/ts/types.ts
@@ -60,7 +60,7 @@ export interface TlsConfig {
 
 /** DNS 配置 — 对应 Rust DnsConfig */
 export interface DnsConfig {
-  /** DNS 模式。默认: 'catcher'。不配置 dns 时使用 reqwest 原生解析。 */
+  /** DNS 模式。默认: 'catcher'。仅显式 native 时使用协议库原生解析。 */
   mode?: 'catcher' | 'native'
   /** 缓存条目数上限。默认: 512 */
   cache_size?: number
@@ -119,7 +119,7 @@ export interface ProxyAuth {
 
 /** 代理配置 — 对应 Rust ProxyConfig */
 export interface ProxyConfig {
-  /** 代理 URL: "http://host:port" | "https://host:port" | "socks5://host:port" | "socks5h://host:port" */
+  /** 代理 URL。Catcher 会把 socks5:// 按 socks5h:// 处理，避免代理场景提前本地解析域名。 */
   url: string
   auth?: ProxyAuth
   /** 不走代理的 hostname 列表 */

--- a/packages/catcher-napi-ws/README.md
+++ b/packages/catcher-napi-ws/README.md
@@ -59,7 +59,6 @@ const ws = new WsClient(
     urls: ['wss://echo.example.com'],
     reconnect: { initial_delay_ms: 500, max_delay_ms: 30000 },
     heartbeat: { interval_ms: 30000, adaptive: true },
-    dns: { cache_ttl_secs: 300, stale_on_error: true },
     msgpack: true,
   },
   (event: WsEvent) => {
@@ -116,6 +115,7 @@ interface WsClientConfig {
 }
 
 interface DnsConfig {
+  mode?: 'catcher' | 'native'             // default: 'catcher'
   cache_size?: number                         // default: 512
   cache_ttl_secs?: number                     // default: 300
   negative_ttl_secs?: number                  // default: 60

--- a/packages/catcher-napi-ws/src/lib.rs
+++ b/packages/catcher-napi-ws/src/lib.rs
@@ -7,7 +7,7 @@
 //!   "headers": { "Authorization": "Bearer ..." },
 //!   "protocols": ["v1", "v2"],
 //!   "per_message_deflate": true,
-//!   "dns": { "cache_ttl_secs": 300 },
+//!   "dns": { "mode": "catcher", "cache_ttl_secs": 300 },
 //!   "msgpack": true,
 //!   "reconnect": { "initial_delay_ms": 500, "max_delay_ms": 30000, "max_attempts": 20 },
 //!   "heartbeat": { "interval_ms": 30000, "pong_timeout_ms": 10000 }
@@ -188,6 +188,7 @@ mod tests {
             "protocols": ["v1"],
             "per_message_deflate": true,
             "dns": {
+                "mode": "catcher",
                 "cache_size": 256,
                 "cache_ttl_secs": 60,
                 "negative_ttl_secs": 30,

--- a/packages/catcher-napi-ws/ts/types.ts
+++ b/packages/catcher-napi-ws/ts/types.ts
@@ -26,7 +26,7 @@ export interface HeartbeatConfig {
 
 /** DNS 配置 — 对应 Rust DnsConfig */
 export interface DnsConfig {
-  /** DNS 模式。默认: 'catcher'。不配置 dns 时使用 reqwest 原生解析。 */
+  /** DNS 模式。默认: 'catcher'。仅显式 native 时使用协议库原生解析。 */
   mode?: 'catcher' | 'native'
   /** 缓存条目数上限。默认: 512 */
   cache_size?: number
@@ -83,7 +83,7 @@ export interface ProxyAuth {
 
 /** 代理配置 — 对应 Rust ProxyConfig */
 export interface ProxyConfig {
-  /** 代理 URL: "http://host:port" | "https://host:port" | "socks5://host:port" | "socks5h://host:port" */
+  /** 代理 URL。Catcher 会把 socks5:// 按 socks5h:// 处理，避免代理场景提前本地解析域名。 */
   url: string
   auth?: ProxyAuth
   /** 不走代理的 hostname 列表 */

--- a/packages/catcher-test-support/Cargo.toml
+++ b/packages/catcher-test-support/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "catcher-test-support"
+version = "0.3.12"
+edition = "2021"
+publish = false
+
+[dependencies]
+tokio = { version = "1", features = ["rt", "net", "io-util", "sync", "time"] }

--- a/packages/catcher-test-support/src/http_proxy.rs
+++ b/packages/catcher-test-support/src/http_proxy.rs
@@ -1,0 +1,170 @@
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+/// HTTP 代理收到的请求。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HttpProxyRequest {
+    Connect { authority: String },
+    Forward { method: String, uri: String },
+}
+
+/// 只接受一个连接的 HTTP 代理探针。
+///
+/// 它用于测试 HTTPS / WSS 是否通过 CONNECT 传递原始域名，以及
+/// `no_proxy` 命中时是否完全没有连接代理。
+pub struct HttpProxyProbe {
+    addr: SocketAddr,
+    request_rx: mpsc::Receiver<io::Result<HttpProxyRequest>>,
+    task: JoinHandle<()>,
+}
+
+impl HttpProxyProbe {
+    pub async fn start() -> io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let (request_tx, request_rx) = mpsc::channel(1);
+
+        let task = tokio::spawn(async move {
+            accept_one(listener, request_tx).await;
+        });
+
+        Ok(Self {
+            addr,
+            request_rx,
+            task,
+        })
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn http_url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    pub async fn wait_for_request(&mut self) -> io::Result<HttpProxyRequest> {
+        match tokio::time::timeout(Duration::from_secs(5), self.request_rx.recv()).await {
+            Ok(Some(result)) => result,
+            Ok(None) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "HTTP proxy probe task stopped before sending result",
+            )),
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out waiting for HTTP proxy request",
+            )),
+        }
+    }
+
+    pub async fn assert_no_request(&mut self, duration: Duration) -> io::Result<()> {
+        match tokio::time::timeout(duration, self.request_rx.recv()).await {
+            Ok(Some(Ok(request))) => Err(io::Error::other(format!(
+                "unexpected HTTP proxy request: {request:?}"
+            ))),
+            Ok(Some(Err(err))) => Err(err),
+            Ok(None) | Err(_) => Ok(()),
+        }
+    }
+}
+
+impl Drop for HttpProxyProbe {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn accept_one(listener: TcpListener, request_tx: mpsc::Sender<io::Result<HttpProxyRequest>>) {
+    let result = async {
+        let (mut stream, _) = listener.accept().await?;
+        let request = read_http_proxy_request(&mut stream).await?;
+        respond_to_proxy_request(&mut stream, &request).await?;
+        Ok((stream, request))
+    }
+    .await;
+
+    match result {
+        Ok((mut stream, request)) => {
+            let _ = request_tx.send(Ok(request)).await;
+            let _ = tokio::time::timeout(Duration::from_millis(200), stream.read_u8()).await;
+        }
+        Err(err) => {
+            let _ = request_tx.send(Err(err)).await;
+        }
+    }
+}
+
+async fn read_http_proxy_request(stream: &mut TcpStream) -> io::Result<HttpProxyRequest> {
+    let mut bytes = Vec::with_capacity(1024);
+    let mut buf = [0; 512];
+
+    loop {
+        let n = stream.read(&mut buf).await?;
+        if n == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "HTTP proxy connection closed before headers",
+            ));
+        }
+        bytes.extend_from_slice(&buf[..n]);
+        if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+        if bytes.len() > 8192 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "HTTP proxy request header too large",
+            ));
+        }
+    }
+
+    let text = String::from_utf8(bytes).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid HTTP proxy request bytes: {e}"),
+        )
+    })?;
+    let first_line = text
+        .lines()
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing request line"))?;
+    let mut parts = first_line.split_whitespace();
+    let method = parts
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing method"))?;
+    let target = parts
+        .next()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing target"))?;
+
+    if method.eq_ignore_ascii_case("CONNECT") {
+        Ok(HttpProxyRequest::Connect {
+            authority: target.to_string(),
+        })
+    } else {
+        Ok(HttpProxyRequest::Forward {
+            method: method.to_string(),
+            uri: target.to_string(),
+        })
+    }
+}
+
+async fn respond_to_proxy_request(
+    stream: &mut TcpStream,
+    request: &HttpProxyRequest,
+) -> io::Result<()> {
+    let response = match request {
+        HttpProxyRequest::Connect { .. } => {
+            b"HTTP/1.1 200 Connection Established\r\nProxy-Agent: catcher-test\r\n\r\n".as_slice()
+        }
+        HttpProxyRequest::Forward { .. } => {
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok".as_slice()
+        }
+    };
+    stream.write_all(response).await
+}

--- a/packages/catcher-test-support/src/lib.rs
+++ b/packages/catcher-test-support/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod http_proxy;
+pub mod socks5;

--- a/packages/catcher-test-support/src/socks5.rs
+++ b/packages/catcher-test-support/src/socks5.rs
@@ -1,0 +1,204 @@
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+/// SOCKS5 代理收到的目标地址。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Socks5Address {
+    Domain(String),
+    Ip(IpAddr),
+}
+
+/// SOCKS5 CONNECT 请求。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Socks5Connect {
+    pub address: Socks5Address,
+    pub port: u16,
+}
+
+/// 只接受一个连接的 SOCKS5 探针。
+///
+/// 它用于测试客户端是否把目标域名交给代理，而不是在本地提前解析成 IP。
+pub struct Socks5Probe {
+    addr: SocketAddr,
+    connect_rx: Option<oneshot::Receiver<io::Result<Socks5Connect>>>,
+    task: JoinHandle<()>,
+}
+
+impl Socks5Probe {
+    pub async fn start() -> io::Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let (connect_tx, connect_rx) = oneshot::channel();
+
+        let task = tokio::spawn(async move {
+            accept_one(listener, connect_tx).await;
+        });
+
+        Ok(Self {
+            addr,
+            connect_rx: Some(connect_rx),
+            task,
+        })
+    }
+
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    pub fn socks5_url(&self) -> String {
+        format!("socks5://{}", self.addr)
+    }
+
+    pub async fn wait_for_connect(&mut self) -> io::Result<Socks5Connect> {
+        let Some(connect_rx) = self.connect_rx.take() else {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "SOCKS5 connect result already consumed",
+            ));
+        };
+
+        match tokio::time::timeout(Duration::from_secs(5), connect_rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "SOCKS5 probe task stopped before sending result",
+            )),
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out waiting for SOCKS5 connect request",
+            )),
+        }
+    }
+}
+
+impl Drop for Socks5Probe {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn accept_one(listener: TcpListener, connect_tx: oneshot::Sender<io::Result<Socks5Connect>>) {
+    let result = async {
+        let (mut stream, _) = listener.accept().await?;
+        let connect = read_socks5_connect(&mut stream).await?;
+        send_socks5_success(&mut stream).await?;
+        Ok((stream, connect))
+    }
+    .await;
+
+    match result {
+        Ok((mut stream, connect)) => {
+            let _ = connect_tx.send(Ok(connect));
+            let _ = serve_one_http_like_response(&mut stream).await;
+        }
+        Err(err) => {
+            let _ = connect_tx.send(Err(err));
+        }
+    }
+}
+
+async fn read_socks5_connect(stream: &mut TcpStream) -> io::Result<Socks5Connect> {
+    let version = stream.read_u8().await?;
+    if version != 0x05 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "SOCKS version is not 5",
+        ));
+    }
+
+    let methods_len = stream.read_u8().await? as usize;
+    let mut methods = vec![0; methods_len];
+    stream.read_exact(&mut methods).await?;
+    if !methods.contains(&0x00) {
+        stream.write_all(&[0x05, 0xff]).await?;
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "SOCKS5 client did not offer no-auth method",
+        ));
+    }
+    stream.write_all(&[0x05, 0x00]).await?;
+
+    let version = stream.read_u8().await?;
+    let command = stream.read_u8().await?;
+    let _reserved = stream.read_u8().await?;
+    let address_type = stream.read_u8().await?;
+
+    if version != 0x05 || command != 0x01 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "SOCKS5 request is not CONNECT",
+        ));
+    }
+
+    let address = match address_type {
+        0x01 => {
+            let mut octets = [0; 4];
+            stream.read_exact(&mut octets).await?;
+            Socks5Address::Ip(IpAddr::V4(Ipv4Addr::from(octets)))
+        }
+        0x03 => {
+            let len = stream.read_u8().await? as usize;
+            let mut bytes = vec![0; len];
+            stream.read_exact(&mut bytes).await?;
+            let domain = String::from_utf8(bytes).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid SOCKS5 domain bytes: {e}"),
+                )
+            })?;
+            Socks5Address::Domain(domain)
+        }
+        0x04 => {
+            let mut octets = [0; 16];
+            stream.read_exact(&mut octets).await?;
+            Socks5Address::Ip(IpAddr::V6(Ipv6Addr::from(octets)))
+        }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unsupported SOCKS5 address type",
+            ))
+        }
+    };
+
+    let mut port_bytes = [0; 2];
+    stream.read_exact(&mut port_bytes).await?;
+    let port = u16::from_be_bytes(port_bytes);
+
+    Ok(Socks5Connect { address, port })
+}
+
+async fn send_socks5_success(stream: &mut TcpStream) -> io::Result<()> {
+    stream
+        .write_all(&[0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0, 0])
+        .await
+}
+
+async fn serve_one_http_like_response(stream: &mut TcpStream) -> io::Result<()> {
+    let mut buf = [0; 2048];
+    let read = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut buf)).await;
+    let n = match read {
+        Ok(Ok(n)) => n,
+        Ok(Err(err)) => return Err(err),
+        Err(_) => return Ok(()),
+    };
+
+    if n == 0 {
+        return Ok(());
+    }
+
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let response = if request.to_ascii_lowercase().contains("upgrade: websocket") {
+        b"HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".as_slice()
+    } else {
+        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok".as_slice()
+    };
+
+    stream.write_all(response).await
+}

--- a/packages/catcher-uniffi/src/lib.rs
+++ b/packages/catcher-uniffi/src/lib.rs
@@ -22,18 +22,14 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
 use catcher_http::{
-    types::http::{HttpClientConfig, HttpMethod, HttpRequest},
+    observability::NetworkQualityEvaluator,
     sse::client::SseClient,
     sse::SseStream,
-    observability::NetworkQualityEvaluator,
+    types::http::{HttpClientConfig, HttpMethod, HttpRequest},
     HttpTransport,
 };
 
-use catcher_ws::{
-    transport::ws_client::WsTransport,
-    types::ws::WsClientConfig,
-    WsEvent, WsHandle,
-};
+use catcher_ws::{transport::ws_client::WsTransport, types::ws::WsClientConfig, WsEvent, WsHandle};
 
 use catcher_core::types::sse::{SseClientConfig, SseMethod};
 use catcher_core::CatcherError as CoreCatcherError;
@@ -81,9 +77,7 @@ fn runtime() -> &'static tokio::runtime::Runtime {
 
 fn parse_headers_json(headers_json: Option<String>) -> HashMap<String, String> {
     match headers_json {
-        Some(s) if !s.is_empty() => {
-            serde_json::from_str(&s).unwrap_or_default()
-        }
+        Some(s) if !s.is_empty() => serde_json::from_str(&s).unwrap_or_default(),
         _ => HashMap::new(),
     }
 }
@@ -146,10 +140,10 @@ impl HttpClient {
     /// Create from JSON config string.
     #[uniffi::constructor]
     pub fn new(config_json: String) -> Result<Self, CatcherError> {
-        let config: HttpClientConfig = serde_json::from_str(&config_json)
-            .map_err(|e| CatcherError::Config(e.to_string()))?;
-        let inner = Arc::new(HttpTransport::new(config)
-            .map_err(|e| CatcherError::Network(e.to_string()))?);
+        let config: HttpClientConfig =
+            serde_json::from_str(&config_json).map_err(|e| CatcherError::Config(e.to_string()))?;
+        let inner =
+            Arc::new(HttpTransport::new(config).map_err(|e| CatcherError::Network(e.to_string()))?);
         Ok(Self { inner })
     }
 
@@ -165,17 +159,20 @@ impl HttpClient {
         let headers = parse_headers_json(headers_json);
         let timeout = timeout_ms.map(|t| t as u64);
         let handle = block_on_aux_thread(async move {
-            inner.execute(HttpRequest {
-                method: HttpMethod::GET,
-                url,
-                headers,
-                body: None,
-                content_type: None,
-                timeout_ms: timeout,
-                ..Default::default()
-            }).await
+            inner
+                .execute(HttpRequest {
+                    method: HttpMethod::GET,
+                    url,
+                    headers,
+                    body: None,
+                    content_type: None,
+                    timeout_ms: timeout,
+                    ..Default::default()
+                })
+                .await
         });
-        let resp = handle.join()
+        let resp = handle
+            .join()
             .map_err(|_| CatcherError::Network("thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))?;
         Ok(http_response_to_dto(resp))
@@ -195,17 +192,20 @@ impl HttpClient {
         let headers = parse_headers_json(headers_json);
         let timeout = timeout_ms.map(|t| t as u64);
         let handle = block_on_aux_thread(async move {
-            inner.execute(HttpRequest {
-                method: HttpMethod::POST,
-                url,
-                headers,
-                body: Some(body),
-                content_type,
-                timeout_ms: timeout,
-                ..Default::default()
-            }).await
+            inner
+                .execute(HttpRequest {
+                    method: HttpMethod::POST,
+                    url,
+                    headers,
+                    body: Some(body),
+                    content_type,
+                    timeout_ms: timeout,
+                    ..Default::default()
+                })
+                .await
         });
-        let resp = handle.join()
+        let resp = handle
+            .join()
             .map_err(|_| CatcherError::Network("thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))?;
         Ok(http_response_to_dto(resp))
@@ -225,17 +225,20 @@ impl HttpClient {
         let headers = parse_headers_json(headers_json);
         let timeout = timeout_ms.map(|t| t as u64);
         let handle = block_on_aux_thread(async move {
-            inner.execute(HttpRequest {
-                method: HttpMethod::PUT,
-                url,
-                headers,
-                body: Some(body),
-                content_type,
-                timeout_ms: timeout,
-                ..Default::default()
-            }).await
+            inner
+                .execute(HttpRequest {
+                    method: HttpMethod::PUT,
+                    url,
+                    headers,
+                    body: Some(body),
+                    content_type,
+                    timeout_ms: timeout,
+                    ..Default::default()
+                })
+                .await
         });
-        let resp = handle.join()
+        let resp = handle
+            .join()
             .map_err(|_| CatcherError::Network("thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))?;
         Ok(http_response_to_dto(resp))
@@ -253,17 +256,20 @@ impl HttpClient {
         let headers = parse_headers_json(headers_json);
         let timeout = timeout_ms.map(|t| t as u64);
         let handle = block_on_aux_thread(async move {
-            inner.execute(HttpRequest {
-                method: HttpMethod::DELETE,
-                url,
-                headers,
-                body: None,
-                content_type: None,
-                timeout_ms: timeout,
-                ..Default::default()
-            }).await
+            inner
+                .execute(HttpRequest {
+                    method: HttpMethod::DELETE,
+                    url,
+                    headers,
+                    body: None,
+                    content_type: None,
+                    timeout_ms: timeout,
+                    ..Default::default()
+                })
+                .await
         });
-        let resp = handle.join()
+        let resp = handle
+            .join()
             .map_err(|_| CatcherError::Network("thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))?;
         Ok(http_response_to_dto(resp))
@@ -283,17 +289,20 @@ impl HttpClient {
         let headers = parse_headers_json(headers_json);
         let timeout = timeout_ms.map(|t| t as u64);
         let handle = block_on_aux_thread(async move {
-            inner.execute(HttpRequest {
-                method: HttpMethod::PATCH,
-                url,
-                headers,
-                body: Some(body),
-                content_type,
-                timeout_ms: timeout,
-                ..Default::default()
-            }).await
+            inner
+                .execute(HttpRequest {
+                    method: HttpMethod::PATCH,
+                    url,
+                    headers,
+                    body: Some(body),
+                    content_type,
+                    timeout_ms: timeout,
+                    ..Default::default()
+                })
+                .await
         });
-        let resp = handle.join()
+        let resp = handle
+            .join()
             .map_err(|_| CatcherError::Network("thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))?;
         Ok(http_response_to_dto(resp))
@@ -335,14 +344,17 @@ impl HttpClient {
                         events.push(serde_json::json!({"type":"data","data":line}).to_string());
                     }
                     Err(e) => {
-                        events.push(serde_json::json!({"type":"error","data":e.to_string()}).to_string());
+                        events.push(
+                            serde_json::json!({"type":"error","data":e.to_string()}).to_string(),
+                        );
                     }
                 }
             }
             Ok::<_, CatcherError>(events)
         });
 
-        handle.join()
+        handle
+            .join()
             .map_err(|_| CatcherError::Network("thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))
     }
@@ -397,7 +409,9 @@ impl From<WsEvent> for WsEventDto {
         match event {
             WsEvent::Connected { url, latency_ms } => WsEventDto::Connected { url, latency_ms },
             WsEvent::Disconnected { code, reason } => WsEventDto::Disconnected { code, reason },
-            WsEvent::Reconnecting { attempt, delay_ms } => WsEventDto::Reconnecting { attempt, delay_ms },
+            WsEvent::Reconnecting { attempt, delay_ms } => {
+                WsEventDto::Reconnecting { attempt, delay_ms }
+            }
             WsEvent::Message { data, is_binary } => WsEventDto::Message { data, is_binary },
             WsEvent::Error { message } => WsEventDto::Error { message },
             WsEvent::HeartbeatRtt { rtt_ms } => WsEventDto::HeartbeatRtt { rtt_ms },
@@ -431,8 +445,8 @@ impl WsClient {
         config_json: String,
         observer: Box<dyn WsEventObserver>,
     ) -> Result<Self, CatcherError> {
-        let config: WsClientConfig = serde_json::from_str(&config_json)
-            .map_err(|e| CatcherError::Config(e.to_string()))?;
+        let config: WsClientConfig =
+            serde_json::from_str(&config_json).map_err(|e| CatcherError::Config(e.to_string()))?;
 
         let urls = config.urls.clone();
         if urls.is_empty() {
@@ -440,10 +454,9 @@ impl WsClient {
         }
 
         // Multi-endpoint racing, reconnect, heartbeat handled by WsTransport::connect
-        let handle = block_on_aux_thread(async move {
-            WsTransport::connect(&config).await
-        });
-        let (ws_handle, mut rx) = handle.join()
+        let handle = block_on_aux_thread(async move { WsTransport::connect(&config).await });
+        let (ws_handle, mut rx) = handle
+            .join()
             .map_err(|_| CatcherError::Network("connect thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))?;
 
@@ -543,8 +556,8 @@ impl SseClientHandle {
         config_json: String,
         observer: Box<dyn SseEventObserver>,
     ) -> Result<Self, CatcherError> {
-        let config: SseClientConfig = serde_json::from_str(&config_json)
-            .map_err(|e| CatcherError::Config(e.to_string()))?;
+        let config: SseClientConfig =
+            serde_json::from_str(&config_json).map_err(|e| CatcherError::Config(e.to_string()))?;
 
         let handle = block_on_aux_thread(async move {
             let mut client = SseClient::connect(config).await?;
@@ -568,14 +581,17 @@ impl SseClientHandle {
             Ok::<_, CatcherError>(())
         });
 
-        handle.join()
+        handle
+            .join()
             .map_err(|_| CatcherError::Network("SSE connect thread panicked".into()))?
             .map_err(|e| CatcherError::Network(e.to_string()))?;
 
         // Spawn an empty task to keep the struct alive.
         // The real work is done synchronously above in block_on_aux_thread.
         let event_task = runtime().spawn(async {});
-        Ok(Self { _event_task: event_task })
+        Ok(Self {
+            _event_task: event_task,
+        })
     }
 }
 
@@ -588,17 +604,15 @@ impl SseClientHandle {
 pub fn catcher_pack(json_input: String) -> Result<Vec<u8>, CatcherError> {
     let value: serde_json::Value = serde_json::from_str(&json_input)
         .map_err(|e| CatcherError::Config(format!("invalid JSON: {e}")))?;
-    catcher_ws::codec::pack(&value)
-        .map_err(|e| CatcherError::Config(e.to_string()))
+    catcher_ws::codec::pack(&value).map_err(|e| CatcherError::Config(e.to_string()))
 }
 
 /// Unpack msgpack binary to a JSON string
 #[uniffi::export]
 pub fn catcher_unpack(data: Vec<u8>) -> Result<String, CatcherError> {
-    let value: serde_json::Value = catcher_ws::codec::unpack_value(&data)
-        .map_err(|e| CatcherError::Config(e.to_string()))?;
-    serde_json::to_string(&value)
-        .map_err(|e| CatcherError::Config(e.to_string()))
+    let value: serde_json::Value =
+        catcher_ws::codec::unpack_value(&data).map_err(|e| CatcherError::Config(e.to_string()))?;
+    serde_json::to_string(&value).map_err(|e| CatcherError::Config(e.to_string()))
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -606,13 +620,12 @@ pub fn catcher_unpack(data: Vec<u8>) -> Result<String, CatcherError> {
 // ═══════════════════════════════════════════════════════════════
 
 // 使用 tokio::sync::Mutex 以便安全地跨 .await 持锁，消除 take/put 竞态。
-static EVALUATOR: std::sync::OnceLock<Arc<tokio::sync::Mutex<NetworkQualityEvaluator>>> = std::sync::OnceLock::new();
+static EVALUATOR: std::sync::OnceLock<Arc<tokio::sync::Mutex<NetworkQualityEvaluator>>> =
+    std::sync::OnceLock::new();
 
 fn evaluator() -> Arc<tokio::sync::Mutex<NetworkQualityEvaluator>> {
     EVALUATOR
-        .get_or_init(|| {
-            Arc::new(tokio::sync::Mutex::new(NetworkQualityEvaluator::new(50)))
-        })
+        .get_or_init(|| Arc::new(tokio::sync::Mutex::new(NetworkQualityEvaluator::new(50))))
         .clone()
 }
 
@@ -641,7 +654,8 @@ pub fn evaluate_quality(host: String) -> Result<String, CatcherError> {
         }
     });
 
-    handle.join()
+    handle
+        .join()
         .map_err(|_| CatcherError::Network("quality thread panicked".into()))?
 }
 

--- a/packages/catcher-ws/Cargo.toml
+++ b/packages/catcher-ws/Cargo.toml
@@ -29,5 +29,6 @@ yawc = { version = "0.3.3", default-features = false, features = ["reqwest"] }
 reqwest = { version = "0.13", default-features = false, features = ["socks"] }
 
 [dev-dependencies]
+catcher-test-support = { path = "../catcher-test-support" }
 sha1 = "0.10"
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["handshake"] }

--- a/packages/catcher-ws/README.md
+++ b/packages/catcher-ws/README.md
@@ -34,12 +34,13 @@ catcher-ws = "0.3.11"
 ### Basic WebSocket connection
 
 ```rust
-use catcher_ws::{DnsConfig, HeartbeatConfig, ReconnectConfig, WsEvent, WsTransport};
+use catcher_ws::{DnsConfig, DnsMode, HeartbeatConfig, ReconnectConfig, WsEvent, WsTransport};
 use catcher_ws::types::ws::WsClientConfig;
 
 let config = WsClientConfig {
     urls: vec!["wss://echo.example.com".into()],
     dns: Some(DnsConfig {
+        mode: DnsMode::Catcher,
         cache_ttl_secs: 300,
         stale_on_error: true,
         ..Default::default()

--- a/packages/catcher-ws/src/ffi/ws_ffi.rs
+++ b/packages/catcher-ws/src/ffi/ws_ffi.rs
@@ -1,8 +1,9 @@
 //! WebSocket C ABI — create / send / close / destroy
 #![allow(clippy::missing_safety_doc)]
 
+use std::collections::HashSet;
 use std::ffi::{c_char, c_void, CStr, CString};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::transport::ws_client::{WsHandle, WsTransport};
 use crate::types::ws::WsClientConfig;
@@ -10,6 +11,32 @@ use crate::types::ws::WsClientConfig;
 use catcher_core::{EventCallback, FfiResult, FfiString, HandleRegistry};
 
 static WS_REGISTRY: HandleRegistry<WsHandle> = HandleRegistry::new();
+
+fn cancelled_ws_ids() -> &'static RwLock<HashSet<usize>> {
+    static CANCELLED: OnceLock<RwLock<HashSet<usize>>> = OnceLock::new();
+    CANCELLED.get_or_init(|| RwLock::new(HashSet::new()))
+}
+
+fn mark_ws_cancelled(id: usize) {
+    let lock = cancelled_ws_ids();
+    match lock.write() {
+        Ok(mut ids) => {
+            ids.insert(id);
+        }
+        Err(poisoned) => {
+            let mut ids = poisoned.into_inner();
+            ids.insert(id);
+        }
+    }
+}
+
+fn is_ws_cancelled(id: usize) -> bool {
+    let lock = cancelled_ws_ids();
+    match lock.read() {
+        Ok(ids) => ids.contains(&id),
+        Err(poisoned) => poisoned.into_inner().contains(&id),
+    }
+}
 
 /// Global tokio runtime for WS async operations (spawning, etc.)
 fn runtime() -> &'static tokio::runtime::Runtime {
@@ -46,6 +73,25 @@ fn invoke_event_callback(cb: EventCallback, event_name: &str, json: String, user
     );
 }
 
+fn invoke_event_callback_if_active(
+    id: usize,
+    cb: EventCallback,
+    event_name: &str,
+    json: String,
+    user_data: usize,
+) -> bool {
+    let lock = cancelled_ws_ids();
+    let ids = match lock.read() {
+        Ok(ids) => ids,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if ids.contains(&id) {
+        return false;
+    }
+    invoke_event_callback(cb, event_name, json, user_data);
+    true
+}
+
 /// 创建 WS 客户端。返回的句柄是注册表 id 直接编码为指针值（id ≥ 1，
 /// 与 null 不冲突），**不指向任何内存** — destroy 之后用旧句柄调用任何
 /// API 都安全返回 "handle not found"，而不是 use-after-free。
@@ -77,16 +123,23 @@ pub unsafe extern "C" fn catcher_ws_create(
     runtime().spawn(async move {
         match WsTransport::connect(&config).await {
             Ok((handle, mut rx)) => {
+                if is_ws_cancelled(id) {
+                    let _ = handle.close(1000, "destroy");
+                    return;
+                }
                 WS_REGISTRY.insert_with_id(id, Arc::new(handle));
 
                 while let Some(event) = rx.recv().await {
                     let json = event.to_ffi_json();
-                    invoke_event_callback(cb, "ws_event", json, ud);
+                    if !invoke_event_callback_if_active(id, cb, "ws_event", json, ud) {
+                        break;
+                    }
                 }
+                WS_REGISTRY.remove(id);
             }
             Err(e) => {
                 let json = error_json(&e.to_string());
-                invoke_event_callback(cb, "ws_error", json, ud);
+                let _ = invoke_event_callback_if_active(id, cb, "ws_error", json, ud);
             }
         }
     });
@@ -171,7 +224,10 @@ pub unsafe extern "C" fn catcher_ws_destroy(handle: *mut c_void) {
         return;
     }
     let id = handle as usize;
-    WS_REGISTRY.remove(id);
+    mark_ws_cancelled(id);
+    if let Some(h) = WS_REGISTRY.remove(id) {
+        let _ = h.close(1000, "destroy");
+    }
 }
 
 // Note: catcher_free_result is provided by catcher-core (ffi_types.rs).

--- a/packages/catcher-ws/src/lib.rs
+++ b/packages/catcher-ws/src/lib.rs
@@ -18,8 +18,9 @@ pub mod ws;
 pub use codec::{pack, unpack, unpack_value};
 pub use transport::ws_client::{WsHandle, WsTransport};
 pub use types::ws::{
-    ApplicationCompressionAlgorithm, ApplicationCompressionConfig, DnsConfig, HeartbeatConfig,
-    ProxyConfig, ReconnectConfig, TlsConfig, TlsVersion, WsClientConfig, WsEvent, WsState,
+    ApplicationCompressionAlgorithm, ApplicationCompressionConfig, DnsConfig, DnsMode,
+    HeartbeatConfig, ProxyConfig, ReconnectConfig, TlsConfig, TlsVersion, WsClientConfig, WsEvent,
+    WsState,
 };
 pub use ws::{
     build_ws_config, decode_application_compression_frame, encode_application_compression_frame,

--- a/packages/catcher-ws/src/transport/ws_client.rs
+++ b/packages/catcher-ws/src/transport/ws_client.rs
@@ -384,7 +384,8 @@ pub(crate) fn build_reqwest_client(
     }
 
     if let Some(ref proxy_config) = config.proxy {
-        let mut proxy = reqwest::Proxy::all(&proxy_config.url)
+        let proxy_url = proxy_config.transport_url();
+        let mut proxy = reqwest::Proxy::all(proxy_url.as_ref())
             .map_err(|e| CatcherError::InvalidConfig(format!("invalid WS proxy URL: {e}")))?;
         if let Some(ref auth) = proxy_config.auth {
             proxy = proxy.basic_auth(&auth.username, &auth.password);
@@ -447,6 +448,7 @@ pub(crate) async fn connect_stream_with_client(
     Ok((stream, latency_ms))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SendStatus {
     Sent,
     Failed,
@@ -476,25 +478,43 @@ where
 }
 
 /// 重连成功后重放缓存的发送命令（Close/NetworkChanged 已在缓存时被过滤）。
-async fn replay_buffered_commands(
-    stream: &mut WsStream,
-    commands: Vec<WsCommand>,
+async fn replay_buffered_commands<S>(
+    stream: &mut S,
+    commands: &[WsCommand],
     config: &WsClientConfig,
-) {
+) -> SendStatus
+where
+    S: futures_util::Sink<Frame> + Unpin,
+{
     for cmd in commands {
         match cmd {
             WsCommand::Text(t) => {
-                if let Ok(msg) = encode_text_message(&t, config) {
-                    let _ = futures_util::SinkExt::send(stream, msg).await;
+                if let Ok(msg) = encode_text_message(t, config) {
+                    let status = send_frame_with_timeout(stream, msg, config.send_timeout_ms).await;
+                    if status != SendStatus::Sent {
+                        return status;
+                    }
                 }
             }
             WsCommand::Binary(d) => {
-                if let Ok(msg) = encode_binary_message(&d, config) {
-                    let _ = futures_util::SinkExt::send(stream, msg).await;
+                if let Ok(msg) = encode_binary_message(d, config) {
+                    let status = send_frame_with_timeout(stream, msg, config.send_timeout_ms).await;
+                    if status != SendStatus::Sent {
+                        return status;
+                    }
                 }
             }
             WsCommand::Close { .. } | WsCommand::NetworkChanged => {}
         }
+    }
+    SendStatus::Sent
+}
+
+fn replay_disconnect_reason(status: SendStatus) -> Option<&'static str> {
+    match status {
+        SendStatus::Sent => None,
+        SendStatus::Failed => Some("replay send failed"),
+        SendStatus::TimedOut => Some("replay send timeout"),
     }
 }
 
@@ -883,14 +903,22 @@ async fn connection_manager(
             });
             match connect_any_endpoint(config, &reqwest_client).await {
                 Ok((url, mut stream, lat)) => {
-                    replay_buffered_commands(&mut stream, buffered_commands, config).await;
-                    current_url = url;
-                    stream_opt = Some(stream);
-                    first_latency = lat;
-                    if let Some(ref mut mgr) = reconnect_mgr {
-                        mgr.on_connected();
+                    let replay_status =
+                        replay_buffered_commands(&mut stream, &buffered_commands, config).await;
+                    if let Some(reason) = replay_disconnect_reason(replay_status) {
+                        let _ = event_tx.send(WsEvent::Disconnected {
+                            code: 1006,
+                            reason: reason.into(),
+                        });
+                    } else {
+                        current_url = url;
+                        stream_opt = Some(stream);
+                        first_latency = lat;
+                        if let Some(ref mut mgr) = reconnect_mgr {
+                            mgr.on_connected();
+                        }
+                        continue;
                     }
-                    continue;
                 }
                 Err(e) => {
                     // 无退避重连兜底时这是终态：补一个 Error 事件，
@@ -993,7 +1021,16 @@ async fn connection_manager(
                 };
 
                 match connect_result {
-                    Ok((stream, lat)) => {
+                    Ok((mut stream, lat)) => {
+                        let replay_status =
+                            replay_buffered_commands(&mut stream, &buffered_commands, config).await;
+                        if let Some(reason) = replay_disconnect_reason(replay_status) {
+                            let _ = event_tx.send(WsEvent::Disconnected {
+                                code: 1006,
+                                reason: reason.into(),
+                            });
+                            continue;
+                        }
                         stream_opt = Some(stream);
                         reconnect_latency_ms = lat;
                         mgr.on_connected();
@@ -1005,13 +1042,6 @@ async fn connection_manager(
             }
 
             if reconnected {
-                // 重连后回放缓存的命令（Close 已被过滤，不会到达这里）
-                if !buffered_commands.is_empty() {
-                    if let Some(mut stream) = stream_opt.take() {
-                        replay_buffered_commands(&mut stream, buffered_commands, config).await;
-                        stream_opt = Some(stream);
-                    }
-                }
                 // 更新延迟供下一轮 Connected 事件使用
                 first_latency = reconnect_latency_ms;
                 continue; // 回到外层循环 → 新的 select loop
@@ -1099,6 +1129,7 @@ mod tests {
             "protocols": ["graphql-ws"],
             "msgpack": true,
             "dns": {
+                "mode": "catcher",
                 "cache_size": 128,
                 "cache_ttl_secs": 30,
                 "host_mapping": {"example.com": "127.0.0.1"}
@@ -1130,6 +1161,7 @@ mod tests {
         let config = WsClientConfig {
             urls: vec![format!("ws://ws.test:{port}")],
             dns: Some(DnsConfig {
+                mode: DnsMode::Catcher,
                 host_mapping: [("ws.test".to_string(), "127.0.0.1".to_string())]
                     .into_iter()
                     .collect(),
@@ -1207,8 +1239,7 @@ mod tests {
     async fn send_frame_times_out_on_stuck_sink() {
         let mut sink = PendingSink;
         let start = Instant::now();
-        let status =
-            send_frame_with_timeout(&mut sink, Frame::text(b"x".to_vec()), 50).await;
+        let status = send_frame_with_timeout(&mut sink, Frame::text(b"x".to_vec()), 50).await;
         assert!(matches!(status, SendStatus::TimedOut));
         assert!(start.elapsed() < Duration::from_secs(2));
     }
@@ -1217,12 +1248,28 @@ mod tests {
     #[tokio::test]
     async fn send_frame_succeeds_on_ready_sink() {
         let mut sink = futures_util::sink::drain();
-        let status =
-            send_frame_with_timeout(&mut sink, Frame::text(b"a".to_vec()), 1_000).await;
+        let status = send_frame_with_timeout(&mut sink, Frame::text(b"a".to_vec()), 1_000).await;
         assert!(matches!(status, SendStatus::Sent));
 
         let status = send_frame_with_timeout(&mut sink, Frame::text(b"b".to_vec()), 0).await;
         assert!(matches!(status, SendStatus::Sent));
+    }
+
+    /// 重放缓存消息时也必须遵守 send_timeout_ms。
+    #[tokio::test]
+    async fn replay_buffered_commands_times_out_on_stuck_sink() {
+        let mut sink = PendingSink;
+        let config = WsClientConfig {
+            send_timeout_ms: 50,
+            ..Default::default()
+        };
+        let commands = vec![WsCommand::Text("hello".to_string())];
+
+        let start = Instant::now();
+        let status = replay_buffered_commands(&mut sink, &commands, &config).await;
+
+        assert!(matches!(status, SendStatus::TimedOut));
+        assert!(start.elapsed() < Duration::from_secs(2));
     }
 
     /// network_changed() 应立即断开并重连，事件序列：
@@ -1497,7 +1544,10 @@ mod tests {
                 break;
             }
         }
-        assert!(got_connected, "should reconnect even without reconnect config");
+        assert!(
+            got_connected,
+            "should reconnect even without reconnect config"
+        );
 
         let _ = handle.close(1000, "done");
         let _ = server.await;

--- a/packages/catcher-ws/src/types/ws.rs
+++ b/packages/catcher-ws/src/types/ws.rs
@@ -1,6 +1,6 @@
 use catcher_core::types::default_true;
 pub use catcher_core::types::network::{ProxyConfig, TlsConfig, TlsVersion};
-pub use catcher_dns::DnsConfig;
+pub use catcher_dns::{DnsConfig, DnsMode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/packages/catcher-ws/tests/local_proxy_test.rs
+++ b/packages/catcher-ws/tests/local_proxy_test.rs
@@ -49,3 +49,11 @@ async fn local_socks5h_proxy_connects_websocket() {
         .unwrap_or_else(|_| "socks5h://127.0.0.1:7890".to_string());
     assert_ws_via_proxy(proxy_url).await;
 }
+
+#[tokio::test]
+#[ignore = "requires a local SOCKS proxy, for example CATCHER_TEST_SOCKS5_PROXY=socks5://127.0.0.1:7890"]
+async fn local_socks5_proxy_connects_websocket() {
+    let proxy_url = std::env::var("CATCHER_TEST_SOCKS5_PROXY")
+        .unwrap_or_else(|_| "socks5://127.0.0.1:7890".to_string());
+    assert_ws_via_proxy(proxy_url).await;
+}

--- a/packages/catcher-ws/tests/proxy_dns_behavior_test.rs
+++ b/packages/catcher-ws/tests/proxy_dns_behavior_test.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::time::Duration;
+
+use catcher_test_support::http_proxy::{HttpProxyProbe, HttpProxyRequest};
+use catcher_test_support::socks5::{Socks5Address, Socks5Probe};
+use catcher_ws::{DnsConfig, DnsMode, ProxyConfig, WsClientConfig, WsTransport};
+use futures_util::StreamExt;
+use tokio::time::timeout;
+
+fn proxy_config(url: String) -> ProxyConfig {
+    ProxyConfig {
+        url,
+        auth: None,
+        no_proxy: Vec::new(),
+    }
+}
+
+fn proxy_config_with_no_proxy(url: String, no_proxy: Vec<String>) -> ProxyConfig {
+    ProxyConfig {
+        url,
+        auth: None,
+        no_proxy,
+    }
+}
+
+fn catcher_dns_mapping() -> DnsConfig {
+    DnsConfig {
+        mode: DnsMode::Catcher,
+        host_mapping: HashMap::from([("example.com".to_string(), "127.0.0.1".to_string())]),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn socks5_proxy_receives_domain_even_when_catcher_dns_is_enabled(
+) -> Result<(), Box<dyn Error>> {
+    let mut proxy = Socks5Probe::start().await?;
+    let config = WsClientConfig {
+        urls: vec!["ws://example.com/socket".to_string()],
+        proxy: Some(proxy_config(proxy.socks5_url())),
+        dns: Some(catcher_dns_mapping()),
+        handshake_timeout_ms: 2_000,
+        ..Default::default()
+    };
+
+    let connect_task = tokio::spawn(async move { WsTransport::connect(&config).await });
+
+    let connect = proxy.wait_for_connect().await?;
+    assert_eq!(
+        connect.address,
+        Socks5Address::Domain("example.com".to_string())
+    );
+    assert_eq!(connect.port, 80);
+
+    let connect_result = connect_task.await?;
+    assert!(
+        connect_result.is_err(),
+        "fake SOCKS5 probe intentionally rejects the WebSocket handshake"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn ws_no_proxy_bypasses_configured_proxy() -> Result<(), Box<dyn Error>> {
+    let mut proxy = HttpProxyProbe::start().await?;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let _ = timeout(Duration::from_secs(2), ws.next()).await;
+    });
+
+    let config = WsClientConfig {
+        urls: vec![format!("ws://127.0.0.1:{port}")],
+        proxy: Some(proxy_config_with_no_proxy(
+            proxy.http_url(),
+            vec!["127.0.0.1".to_string()],
+        )),
+        handshake_timeout_ms: 2_000,
+        ..Default::default()
+    };
+
+    let (handle, mut events) = WsTransport::connect(&config).await?;
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await?
+        .expect("connected event");
+    assert!(
+        matches!(event, catcher_ws::WsEvent::Connected { .. }),
+        "unexpected event: {event:?}"
+    );
+    let _ = handle.close(1000, "no proxy test");
+
+    proxy.assert_no_request(Duration::from_millis(200)).await?;
+    server.await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn http_proxy_connect_receives_domain_for_wss_even_when_catcher_dns_is_enabled(
+) -> Result<(), Box<dyn Error>> {
+    let mut proxy = HttpProxyProbe::start().await?;
+    let config = WsClientConfig {
+        urls: vec!["wss://example.com/socket".to_string()],
+        proxy: Some(proxy_config(proxy.http_url())),
+        dns: Some(catcher_dns_mapping()),
+        handshake_timeout_ms: 2_000,
+        ..Default::default()
+    };
+
+    let connect_task = tokio::spawn(async move { WsTransport::connect(&config).await });
+
+    let request = proxy.wait_for_request().await?;
+    assert_eq!(
+        request,
+        HttpProxyRequest::Connect {
+            authority: "example.com:443".to_string()
+        }
+    );
+
+    let connect_result = connect_task.await?;
+    assert!(
+        connect_result.is_err(),
+        "fake HTTP proxy closes after CONNECT, so WSS should fail"
+    );
+
+    Ok(())
+}

--- a/packages/catcher_core/README.md
+++ b/packages/catcher_core/README.md
@@ -40,6 +40,7 @@ void main() async {
     retry: RetryConfig(maxAttempts: 3, backoff: 'Fixed'),
     pool: PoolConfig(keepAlive: true, maxIdlePerHost: 10),
     dns: DnsConfig(
+      mode: 'catcher',
       cacheSize: 512,
       cacheTtlSecs: 300,
       staleTtlSecs: 3600,
@@ -73,7 +74,6 @@ void main() async {
     urls: ['wss://echo.example.com'],
     reconnect: WsReconnectConfig(initialDelayMs: 1000, maxDelayMs: 30000),
     heartbeat: WsHeartbeatConfig(intervalMs: 30000, adaptive: true),
-    dns: DnsConfig(cacheTtlSecs: 300, staleOnError: true),
     msgpack: true,
   ));
 
@@ -115,6 +115,7 @@ final unpacked = unpack(packed);                   // Map<String, dynamic>
 final config = HttpClientConfig(
   baseUrl: 'https://api.example.com',
   dns: DnsConfig(
+    mode: 'catcher',
     cacheSize: 512,
     cacheTtlSecs: 300,
     negativeTtlSecs: 60,
@@ -135,7 +136,7 @@ final config = HttpClientConfig(
 |------|-------------|
 | `CatcherHttpClient` | HTTP client wrapper (get, post, put, delete, patch) |
 | `HttpClientConfig` | Base URL, timeouts, pool, retry, circuit breaker, `dns`, `msgpack` |
-| `DnsConfig` | cacheSize, cacheTtlSecs, negativeTtlSecs, staleTtlSecs, staleOnError, nameservers, hostMapping |
+| `DnsConfig` | mode, cacheSize, cacheTtlSecs, negativeTtlSecs, staleTtlSecs, staleOnError, nameservers, hostMapping |
 | `HttpResponse` | status, headers, body bytes, elapsedMs, bodyAsString |
 | `RetryConfig` | maxAttempts, backoff, jitter |
 | `CircuitBreakerConfig` | failureThreshold, resetTimeoutMs |

--- a/packages/catcher_core/lib/src/ws_client.dart
+++ b/packages/catcher_core/lib/src/ws_client.dart
@@ -37,6 +37,7 @@ class CatcherWsClient {
       StreamController<WsEvent>.broadcast();
 
   NativeCallable<EventCallbackNative>? _nativeCallback;
+  bool _disposed = false;
 
   CatcherWsClient(WsClientConfig config) {
     final lib = loadCatcherLibrary();
@@ -80,22 +81,24 @@ class CatcherWsClient {
 
         // Free the CStrings that Rust leaked via CString::into_raw()
         _freeEventData(eventType, eventData);
+        if (_disposed) {
+          return;
+        }
 
         final Map<String, dynamic> json;
         try {
           json = jsonDecode(jsonStr) as Map<String, dynamic>;
         } catch (_) {
-          _eventController.add(WsErrorEvent('Failed to parse event: $jsonStr'));
+          _emitEvent(WsErrorEvent('Failed to parse event: $jsonStr'));
           return;
         }
 
         if (typeStr == 'ws_error' || json.containsKey('error')) {
-          _eventController
-              .add(WsErrorEvent(json['error']?.toString() ?? jsonStr));
+          _emitEvent(WsErrorEvent(json['error']?.toString() ?? jsonStr));
           return;
         }
 
-        _eventController.add(_parseWsEvent(json));
+        _emitEvent(_parseWsEvent(json));
       },
     );
 
@@ -163,21 +166,27 @@ class CatcherWsClient {
 
   /// Release all resources
   void dispose() {
-    // Close native callback FIRST to prevent Rust from invoking
-    // the function pointer after the handle is destroyed.
-    _nativeCallback?.close();
-    _nativeCallback = null;
+    if (_disposed) return;
+    _disposed = true;
 
     if (_handle != null && _handle != nullptr) {
       _destroy(_handle!);
       _handle = null;
     }
+    _nativeCallback?.close();
+    _nativeCallback = null;
     if (!_eventController.isClosed) {
       _eventController.close();
     }
   }
 
   // ── Internal ──
+
+  void _emitEvent(WsEvent event) {
+    if (!_disposed && !_eventController.isClosed) {
+      _eventController.add(event);
+    }
+  }
 
   void _ensureHandle() {
     if (_handle == null || _handle == nullptr) {

--- a/packages/catcher_core/test/catcher_core_integration_test.dart
+++ b/packages/catcher_core/test/catcher_core_integration_test.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:catcher_core/catcher_core.dart';
 
+import 'http_test_server.dart';
+
 void main() {
   // Skip entire test file if no native library is available
   final ffiPath = Platform.environment['CATCHER_FFI_PATH'];
@@ -20,11 +22,20 @@ void main() {
   }
 
   group('FFI HTTP client', () {
+    late LocalHttpEchoServer server;
     late CatcherHttpClient client;
+
+    setUpAll(() async {
+      server = await LocalHttpEchoServer.start();
+    });
+
+    tearDownAll(() async {
+      await server.close();
+    });
 
     setUp(() {
       client = CatcherHttpClient(HttpClientConfig(
-        baseUrl: 'https://httpbin.org',
+        baseUrl: server.baseUrl,
         retry: RetryConfig(maxAttempts: 2),
       ));
     });

--- a/packages/catcher_core/test/catcher_core_test.dart
+++ b/packages/catcher_core/test/catcher_core_test.dart
@@ -19,6 +19,7 @@ void main() {
         baseUrl: 'https://api.example.com',
         retry: RetryConfig(maxAttempts: 3),
         dns: DnsConfig(
+          mode: 'catcher',
           cacheSize: 1024,
           cacheTtlSecs: 600,
           negativeTtlSecs: 30,
@@ -32,6 +33,7 @@ void main() {
       final json = config.toJson();
       expect(json['base_url'], 'https://api.example.com');
       expect(json['retry']['max_attempts'], 3);
+      expect(json['dns']['mode'], 'catcher');
       expect(json['dns']['cache_size'], 1024);
       expect(json['dns']['cache_ttl_secs'], 600);
       expect(json['dns']['negative_ttl_secs'], 30);
@@ -107,13 +109,17 @@ void main() {
         urls: ['wss://example.com'],
         perMessageDeflate: true,
         reconnect: WsReconnectConfig(maxAttempts: 3),
-        dns: DnsConfig(hostMapping: {'example.com': '127.0.0.1'}),
+        dns: DnsConfig(
+          mode: 'catcher',
+          hostMapping: {'example.com': '127.0.0.1'},
+        ),
         msgpack: true,
       );
       final json = config.toJson();
       expect(json['urls'], ['wss://example.com']);
       expect(json['per_message_deflate'], true);
       expect(json['reconnect']['max_attempts'], 3);
+      expect(json['dns']['mode'], 'catcher');
       expect(json['dns']['host_mapping']['example.com'], '127.0.0.1');
       expect(json['msgpack'], true);
     });

--- a/packages/catcher_core/test/ffi_roundtrip_test.dart
+++ b/packages/catcher_core/test/ffi_roundtrip_test.dart
@@ -22,6 +22,8 @@ import 'package:catcher_core/src/ffi_bindings.dart';
 import 'package:ffi/ffi.dart';
 import 'package:test/test.dart';
 
+import 'http_test_server.dart';
+
 void main() {
   // Skip entire suite if the native library is not available.
   final ffiPath = Platform.environment['CATCHER_FFI_PATH'];
@@ -156,7 +158,7 @@ void main() {
   group('HTTP client lifecycle', () {
     test('create and destroy client without error', () {
       final client = CatcherHttpClient(HttpClientConfig(
-        baseUrl: 'https://httpbin.org',
+        baseUrl: 'http://127.0.0.1',
         connectTimeoutMs: 5000,
         responseTimeoutMs: 10000,
       ));
@@ -179,7 +181,7 @@ void main() {
 
     test('dispose is idempotent', () {
       final client = CatcherHttpClient(HttpClientConfig(
-        baseUrl: 'https://httpbin.org',
+        baseUrl: 'http://127.0.0.1',
       ));
       client.dispose();
       // Second dispose should not crash
@@ -188,12 +190,21 @@ void main() {
     });
   });
 
-  group('HTTP roundtrip (network required)', () {
+  group('HTTP roundtrip (local server)', () {
+    late LocalHttpEchoServer server;
     CatcherHttpClient? client;
+
+    setUpAll(() async {
+      server = await LocalHttpEchoServer.start();
+    });
+
+    tearDownAll(() async {
+      await server.close();
+    });
 
     setUp(() {
       client = CatcherHttpClient(HttpClientConfig(
-        baseUrl: 'https://httpbin.org',
+        baseUrl: server.baseUrl,
         connectTimeoutMs: 5000,
         responseTimeoutMs: 15000,
         retry: RetryConfig(maxAttempts: 2),
@@ -238,7 +249,7 @@ void main() {
       expect(resp.status, equals(200));
       final body = jsonDecode(resp.bodyAsString) as Map;
       final headers = body['headers'] as Map;
-      // httpbin capitalizes headers as "X-Custom-Header" or similar
+      // Header name casing can vary by transport.
       final hasHeader = headers.keys.any(
         (k) => (k as String).toLowerCase() == 'x-custom-header',
       );
@@ -281,7 +292,7 @@ void main() {
   group('Per-request cancel API', () {
     test('cancelRequest returns false for non-existent request', () {
       final client = CatcherHttpClient(HttpClientConfig(
-        baseUrl: 'https://httpbin.org',
+        baseUrl: 'http://127.0.0.1',
       ));
       // No requests in flight — cancel should return false
       final result = client.cancelRequest(99999);
@@ -294,7 +305,7 @@ void main() {
   group('Adaptive timeout API', () {
     test('setAdaptiveToggle does not crash', () {
       final client = CatcherHttpClient(HttpClientConfig(
-        baseUrl: 'https://httpbin.org',
+        baseUrl: 'http://127.0.0.1',
       ));
       // Enable
       client.setAdaptiveTimeout(

--- a/packages/catcher_core/test/http_test_server.dart
+++ b/packages/catcher_core/test/http_test_server.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:io';
+
+class LocalHttpEchoServer {
+  LocalHttpEchoServer._(this._server, this.baseUrl);
+
+  final HttpServer _server;
+  final String baseUrl;
+
+  static Future<LocalHttpEchoServer> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen(_handleRequest);
+    return LocalHttpEchoServer._(
+      server,
+      'http://127.0.0.1:${server.port}',
+    );
+  }
+
+  Future<void> close() async {
+    await _server.close(force: true);
+  }
+
+  static Future<void> _handleRequest(HttpRequest request) async {
+    final path = request.uri.path;
+
+    if (request.method == 'GET' && path == '/get') {
+      await _writeJson(request.response, 200, {
+        'url': request.requestedUri.toString(),
+      });
+      return;
+    }
+
+    if (request.method == 'GET' && path == '/status/404') {
+      await _writeJson(request.response, 404, {
+        'status': 404,
+      });
+      return;
+    }
+
+    if (request.method == 'POST' && path == '/post') {
+      final data = await utf8.decoder.bind(request).join();
+      await _writeJson(request.response, 200, {
+        'data': data,
+      });
+      return;
+    }
+
+    if (request.method == 'GET' && path == '/headers') {
+      final headers = <String, String>{};
+      request.headers.forEach((name, values) {
+        headers[name] = values.join(', ');
+      });
+      await _writeJson(request.response, 200, {
+        'headers': headers,
+      });
+      return;
+    }
+
+    await _writeJson(request.response, 404, {
+      'error': 'not found',
+    });
+  }
+
+  static Future<void> _writeJson(
+    HttpResponse response,
+    int statusCode,
+    Object body,
+  ) async {
+    response.statusCode = statusCode;
+    response.headers.contentType = ContentType.json;
+    response.write(jsonEncode(body));
+    await response.close();
+  }
+}

--- a/packages/test/adapters/rust-adapter.ts
+++ b/packages/test/adapters/rust-adapter.ts
@@ -35,6 +35,7 @@ export function createRustHttpClient(config: RustHttpConfig) {
     || config.dnsHostMapping != null
   const dnsConfig = hasDns
     ? {
+        mode: 'catcher',
         cache_size: config.dnsCacheSize ?? 512,
         cache_ttl_secs: config.dnsCacheTtl ?? 300,
         negative_ttl_secs: config.dnsNegativeTtl ?? 60,

--- a/packages/test/benchmark/napi-agent.bench.ts
+++ b/packages/test/benchmark/napi-agent.bench.ts
@@ -40,6 +40,7 @@ describe('napi — client creation cost', () => {
         idle_timeout_secs: 90,
       },
       dns: {
+        mode: 'catcher',
         cache_size: 512,
         cache_ttl_secs: 300,
         negative_ttl_secs: 60,

--- a/packages/test/integration/napi-dns.test.ts
+++ b/packages/test/integration/napi-dns.test.ts
@@ -101,6 +101,7 @@ describe('NAPI DNS cache — StaleAwareDnsResolver', () => {
       connect_timeout_ms: 5000,
       response_timeout_ms: 10_000,
       dns: {
+        mode: 'catcher',
         cache_size: 1024,
         cache_ttl_secs: 600,
         negative_ttl_secs: 30,
@@ -119,6 +120,7 @@ describe('NAPI DNS cache — StaleAwareDnsResolver', () => {
       connect_timeout_ms: 5000,
       response_timeout_ms: 10_000,
       dns: {
+        mode: 'catcher',
         cacheSize: 256,
         cacheTtlSecs: 120,
         negativeTtlSecs: 10,
@@ -152,8 +154,8 @@ describe('NAPI DNS cache — StaleAwareDnsResolver', () => {
     expect(elapsed).toBeLessThan(DNS_DELAY_MS)
   })
 
-  it('default DnsConfig enables caching (no explicit dns field)', async () => {
-    // No dns config at all — uses system DNS with default cache
+  it('omitting dns config uses the transport resolver', async () => {
+    // No dns config at all: no DnsConfig is constructed.
     const client = new HttpClient(JSON.stringify({
       base_url: `http://127.0.0.1:${httpServer.port}`,
       connect_timeout_ms: 5000,

--- a/packages/test/network/slow-dns-proxy.ts
+++ b/packages/test/network/slow-dns-proxy.ts
@@ -8,7 +8,7 @@
  * Usage:
  *   const proxy = createSlowDnsProxy(200)  // 200ms delay
  *   proxy.start()  // returns { port } once listening
- *   // Configure catcher: dns: { nameservers: [`127.0.0.1:${port}`], cache_ttl_secs: 300 }
+ *   // Configure catcher: dns: { mode: 'catcher', nameservers: [`127.0.0.1:${port}`], cache_ttl_secs: 300 }
  *   proxy.stop()
  */
 import dgram from 'node:dgram'


### PR DESCRIPTION
## Summary
- keep Catcher DNS as the explicit DNS mode while preventing proxy paths from resolving target domains locally
- normalize socks5 proxy URLs to remote-DNS behavior and apply proxy/TLS/DNS consistently for HTTP and WS
- add deterministic proxy DNS tests for SOCKS5, HTTP CONNECT, and no_proxy bypass behavior
- document mobile Clash/VPN/proxy compatibility requirements and validation matrix
- harden WS replay/dispose and network quality unsubscribe behavior from the review fixes

## Verification
- cargo test -p catcher-http --test proxy_dns_behavior_test -- --nocapture
- cargo test -p catcher-ws --test proxy_dns_behavior_test -- --nocapture
- cargo test -p catcher-test-support -p catcher-http -p catcher-ws
- cargo clippy -p catcher-test-support -p catcher-http -p catcher-ws --all-targets -- -D warnings
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm typecheck
- pnpm test
- local Clash proxy ignored tests for HTTP and WS using http://127.0.0.1:7890, socks5://127.0.0.1:7890, socks5h://127.0.0.1:7890

Note: Dart/Flutter tests were not run because dart/flutter/fvm are not installed on this machine.