### PR TITLE
fix: PR #13–15 review findings + release 0.3.13 (issues #28–34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,14 @@ jobs:
           workspaces: "packages -> target"
       - run: cd packages && cargo check --workspace
       - run: cd packages && cargo clippy --workspace --all-targets -- -D warnings
-      - run: cd packages && cargo test --workspace
+      # `cargo test --workspace` 使用各 crate 默认 features：catcher-http 默认含
+      # `hickory-dns`、catcher-ws 始终启用 `reqwest-resolver`，因此 proxy_dns_behavior_test
+      # 会在此运行。这是「代理路径目标域名不被本地解析」对 reqwest 内部行为依赖的唯一护栏
+      # （见 docs/arch-rs/04-transport.md，issue #031）。升级 reqwest 时务必确认其通过。
+      #
+      # `--no-fail-fast`：默认 cargo test 在第一个失败的测试二进制处停止，会让单个 flaky
+      # 测试（如 catcher-ffi quality_test）掩盖后续整个套件的执行结果（issue #033）。
+      - run: cd packages && cargo test --workspace --no-fail-fast
 
   dart-ffi-roundtrip:
     runs-on: ubuntu-latest

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,15 +1,15 @@
 {
-  "packages/catcher-core-ts": "0.3.12",
-  "packages/catcher-http-ts": "0.3.12",
-  "packages/catcher-ws-ts": "0.3.12",
-  "packages/catcher-web": "0.3.12",
-  "packages/catcher-napi-http": "0.3.12",
-  "packages/catcher-napi-ws": "0.3.12",
-  "packages/catcher-core": "0.3.12",
-  "packages/catcher-dns": "0.3.12",
-  "packages/catcher-http": "0.3.12",
-  "packages/catcher-ws": "0.3.12",
-  "packages/catcher-ffi": "0.3.12",
-  "packages/catcher-uniffi": "0.3.12",
-  "packages/catcher_core": "0.3.12"
+  "packages/catcher-core-ts": "0.3.13",
+  "packages/catcher-http-ts": "0.3.13",
+  "packages/catcher-ws-ts": "0.3.13",
+  "packages/catcher-web": "0.3.13",
+  "packages/catcher-napi-http": "0.3.13",
+  "packages/catcher-napi-ws": "0.3.13",
+  "packages/catcher-core": "0.3.13",
+  "packages/catcher-dns": "0.3.13",
+  "packages/catcher-http": "0.3.13",
+  "packages/catcher-ws": "0.3.13",
+  "packages/catcher-ffi": "0.3.13",
+  "packages/catcher-uniffi": "0.3.13",
+  "packages/catcher_core": "0.3.13"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file. See [releas
 
 > 网络韧性大版本：主动网络切换恢复、移动端代理/VPN 兼容（含远端 DNS）、以及一组配置行为的对齐。
 > **升级前请阅读「⚠️ 行为变更」** —— 多数变更对默认配置无影响，但 DNS、代理、TLS 几处默认行为有调整。
-> 升级指南见 [`docs/user-manual/migration.md`](./docs/user-manual/migration.md) 的「版本升级：0.3.x → 0.3.13」一节。
+> 📄 完整发版说明（含 API 差距、升级清单）见 [`docs/releases/0.3.13.md`](./docs/releases/0.3.13.md)；
+> 简明迁移表见 [`docs/user-manual/migration.md`](./docs/user-manual/migration.md) 的「版本升级：0.3.x → 0.3.13」一节。
 
 ### ✨ Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to this project will be documented in this file. See [release-please](https://github.com/googleapis/release-please) for automated management.
 
+## 0.3.13 (2026-06-13)
+
+> 网络韧性大版本：主动网络切换恢复、移动端代理/VPN 兼容（含远端 DNS）、以及一组配置行为的对齐。
+> **升级前请阅读「⚠️ 行为变更」** —— 多数变更对默认配置无影响，但 DNS、代理、TLS 几处默认行为有调整。
+> 升级指南见 [`docs/user-manual/migration.md`](./docs/user-manual/migration.md) 的「版本升级：0.3.x → 0.3.13」一节。
+
+### ✨ Features
+
+- **主动网络切换恢复 `networkChanged()`**：网络环境切换（WiFi↔蜂窝、VPN 连接/断开/换节点）后，旧连接会静默变成半开连接。宿主 App 从 OS 拿到网络变化信号后调用 `networkChanged()`，立即完成恢复，不再等被动超时（WS 心跳 10–30s / TCP keepalive 20s / DNS 缓存最长 300s）。
+  - **HTTP**（`HttpTransport::network_changed()` / `client.networkChanged()`）：清空 DNS 缓存并重建解析器、热替换底层客户端丢弃整个旧连接池、重置熔断器。
+  - **WebSocket**（`WsHandle::network_changed()` / `ws.networkChanged()`）：立即丢弃半开连接（不发 Close 帧）、清 DNS、重置退避并立即重连、多端点重新竞速。
+  - **catcher-dns**：新增 `DnsResolver::clear_cache()`，并在网络切换时重建 resolver 以读取新网络（如 VPN 下发）的 nameserver。
+  - 全平台绑定：C ABI（`catcher_ws_network_changed` / `catcher_http_network_changed`）、napi、UniFFI（Kotlin/Swift）、Dart。
+- **移动端显式代理 / VPN 兼容**：HTTP 与 WebSocket 现在共享 `catcher-core` 的 `ProxyConfig` / `TlsConfig`，一致支持 HTTP 代理、SOCKS5/SOCKS5h、HTTP CONNECT，以及 `no_proxy` 旁路。启用 `reqwest/socks` feature。
+- **WebSocket 迁移到 reqwest 传输层**：使 WS 获得与 HTTP 一致的代理 / TLS / DNS 能力；新增 `WsClientConfig.proxy`、`WsClientConfig.tls`、`WsClientConfig.send_timeout_ms`（默认 10000ms，防半开发送阻塞事件循环）。
+
+### ⚠️ Behavior Changes（升级敏感，请逐条确认）
+
+- **DNS 改为按需启用（opt-in）**：此前 HTTP/WS **总是**构建 Catcher DNS 解析器（即使未配置 `dns`）。现在 **不配置 `dns` 即使用协议库原生解析**；仅当提供 `dns` 配置（`mode` 默认 `catcher`）或显式 `dns.mode = "catcher"` 时才启用 Catcher DNS（缓存 / 旧缓存兜底 / host mapping / 自定义 nameserver）。**影响**：此前依赖隐式 DNS 缓存的调用方，升级后若未显式配置 `dns` 将失去缓存。
+- **不再静默回退到公共 DNS**：此前读取系统 DNS 配置失败时会静默回退到 hickory 默认（公共）nameserver（如 `8.8.8.8`）。现在会返回 `DnsError`，除非显式设置新增字段 `fallback_to_default_nameservers = true`（默认 `false`）。**影响**：移动端/受限网络下不再意外把 DNS 查询发往公共服务器。
+- **`socks5://` 自动按 `socks5h://` 处理**：代理路径下目标域名交给代理远端解析，避免本地提前解析成 IP 破坏 Clash fake-ip / VPN 分流。**影响**：无法再通过 `socks5://` 强制本地解析（这是有意的修复）。
+- **`tls_sni_override` 在原生 transport 改为显式报错**：此前在 Rust（catcher-http / catcher-ws）路径被**静默忽略**（reqwest 无法覆写 SNI 主机名）。现在设置该字段会在构建客户端时返回 `InvalidConfig`，不再假装生效。纯 TS 的 Node Agent 路径（`@eric8810/catcher-http` 的 `servername`）仍支持。
+- **WebSocket 单连接多 IP 握手故障转移已移除**：随 WS 迁移到 reqwest，按 A 记录逐个 IP 重试握手的逻辑（`connect_with_resolved_addrs`）被移除，改由 reqwest 的连接层（happy-eyeballs）处理。**影响**：多 IP 主机在握手层的逐 IP 重试能力减弱（多端点竞速 `urls: [...]` 不受影响）。
+- **WebSocket FFI 销毁语义修正**：`catcher_ws_destroy` 现在会取消事件循环并关闭连接，而非仅从注册表移除句柄。修复了销毁后事件循环仍运行、仍回调宿主 `user_data` 的 use-after-free 风险。
+
+### 🐛 Bug Fixes
+
+- **FFI 句柄 use-after-free**：句柄中直接编码 registry id，消除回收复用导致的 use-after-free。
+- **网络切换期间的失败不再惩罚新网络**：在途请求启动时快照「网络代际」，切换后失败不计入熔断器（network-generation gating）。
+- **DNS 缓存清空后不被旧网络结果回填**：`clear_cache()` 后，后台 stale 刷新与前台解析都按代际拒绝写入旧结果。
+- **network-quality 取消订阅泄漏**：`unsubscribe()` 现在会 `abort()` 后台任务，而非仅发送取消信号。
+- **WS 重连命令重放遵守 `send_timeout_ms`**：重放缓冲命令时不会因半开 sink 卡死事件循环。
+
+### 🔄 Internal / 无公开 API 影响
+
+- 本周期内曾引入又移除了 `network_path_id` / `networkPathId` 配置字段（先加于代理 PR、后移除）——**对外 API 净零变化**，因为它从未随正式版本发布。其职责由 `networkChanged()` 承担。
+- 共享类型 `ProxyConfig` / `ProxyAuth` / `TlsConfig` / `TlsVersion` 上移至 `catcher-core` 并在 `catcher-http` / `catcher-ws` 重导出：Rust 调用方经 `catcher_http::types::http::*` 的导入路径**保持源码兼容**。
+- 配置 JSON 反序列化未启用 `deny_unknown_fields`：传入未知/已移除字段会被静默忽略，故绑定层 JSON 调用方不会因字段移除而中断。
+
+### 📝 Documentation
+
+- 新增 issues #028–#031（已修复）与 #032（feature gap：WS 尚未实现 `pin_sha256` 证书固定）。
+- `docs/user-manual/resilience.md` 第七节：`networkChanged()` 各平台用法、防抖建议，以及「在途请求不会被自动恢复，需配合 `cancelAll()`」说明。
+- `docs/arch-rs/04-transport.md`：代理 × DNS 契约，及「代理路径目标域名不本地解析」对 reqwest 内部行为的依赖（升级 reqwest 必须重跑 `proxy_dns_behavior_test`）。
+
 ## 0.3.12 (2026-06-08)
 
 ### 🐛 Bug Fixes

--- a/docs/arch-rs/04-transport.md
+++ b/docs/arch-rs/04-transport.md
@@ -252,8 +252,9 @@ pub fn build_stale_aware_resolver(config: &DnsConfig) -> Result<Arc<StaleAwareDn
 
 ## 代理与 DNS 的配合
 
-HTTP 和 WebSocket 使用同一套网络配置：`proxy`、`dns`、`tls` 和
-`network_path_id` 的语义必须一致。
+HTTP 和 WebSocket 使用同一套网络配置：`proxy`、`dns`、`tls`
+的语义必须一致。网络环境切换后的主动恢复由 `networkChanged()` API 承担
+（清 DNS 缓存、热重建连接池、重置熔断器），见 `docs/user-manual/resilience.md`。
 
 当调用方传入 `proxy.url = "socks5://..."` 时，Catcher 内部必须按
 `socks5h://...` 交给 reqwest。原因是：
@@ -283,6 +284,14 @@ HTTP 和 WebSocket 使用同一套网络配置：`proxy`、`dns`、`tls` 和
 - `catcher-ws/tests/proxy_dns_behavior_test.rs` 验证 WebSocket 同样遵守该行为。
 - `catcher-http/tests/local_proxy_test.rs` 和 `catcher-ws/tests/local_proxy_test.rs`
   保留为 `#[ignore]`，用于发版前手动连接真实 Clash 或本地代理。
+
+> ⚠️ **对 reqwest 内部行为的隐式依赖（issue #031）**：上述「代理路径目标域名不被本地
+> 解析」的保证，建立在 reqwest「走代理时不调用自定义 `dns_resolver`」这一**实现细节**之上，
+> 而非其稳定 API 的明文承诺。代码中没有、也无法（resolver 仍需服务 no_proxy/直连 host）
+> 显式禁用代理路径上的本地解析。`proxy_dns_behavior_test` 是唯一的回归护栏，随
+> `cargo test --workspace`（catcher-http 默认启用 `hickory-dns`，catcher-ws 始终启用
+> `reqwest-resolver`）在 CI 运行。**升级 reqwest 版本时，必须确认这两个测试通过**，否则
+> 目标域名可能悄悄退回本地解析、以 IP 泄漏给代理，破坏 Clash 域名分流。
 
 ---
 

--- a/docs/issues/028-tls-sni-override-noop-rust-path.md
+++ b/docs/issues/028-tls-sni-override-noop-rust-path.md
@@ -1,0 +1,101 @@
+# Bug: `tlsSniOverride` 在 Rust/native 路径静默失效，且与纯 TS 路径行为不一致
+
+**严重程度**: 🟡 Medium — 配置项被接受但 Rust 路径完全不生效（静默错误行为）；与 TS 路径行为分裂，安全/MITM/域前置场景下会误导调用方
+
+**状态**: Fixed — 采用方案 A：原生 transport 在设置 `tls_sni_override` 时显式返回 `InvalidConfig`，并更新过时的 reqwest 注释
+
+**影响包**: `catcher-http`、`catcher-ws`、`catcher-core`（类型）、全部绑定（napi / TS / Dart / UniFFI）
+
+**位置**:
+- `packages/catcher-http/src/transport/tls.rs:101-105`（非 pinning 路径）
+- `packages/catcher-http/src/transport/tls.rs:167-171`（pinning 路径）
+- `packages/catcher-ws/src/transport/ws_client.rs:361-363`
+- `packages/catcher-core/src/types/network.rs:50`（字段定义）
+- `packages/catcher-http-ts/src/agent/shared-agent.ts:147-148`（TS 路径，**生效**）
+
+---
+
+## 现象
+
+调用方设置 `TlsConfig.tls_sni_override = "custom-sni.example.com"`，期望 TLS 握手时发送的 SNI 主机名被覆写为该值（域前置、MITM 代理、证书域名与连接域名不一致等场景的核心用途）。
+
+- **Rust / native 路径（catcher-http、catcher-ws）**：该值被**完全忽略**，SNI 仍然取自 URL 的 host。
+- **纯 TS 路径（catcher-http-ts 的 Node Agent）**：该值**生效**（`tlsAgentOpts.servername = tls.tlsSniOverride`）。
+
+同一个配置字段在两条 transport 上行为不同，且 Rust 路径无任何报错或日志 —— 调用方无法察觉它没生效。
+
+## 根因
+
+reqwest 0.13 的 `ClientBuilder::tls_sni(bool)` 只控制**是否发送 SNI 扩展**（enable/disable），**不接受主机名**。当前代码：
+
+```rust
+// tls.rs:101-105 — 非 pinning 路径
+// NOTE: reqwest 0.12 tls_sni() takes a bool (enable/disable SNI), not a hostname.
+if let Some(ref _sni) = config.tls_sni_override {   // 注意：变量名是 _sni —— 值被丢弃
+    builder = builder.tls_sni(true);                 // 而 SNI 本来就默认开启，此调用近乎 no-op
+}
+```
+
+```rust
+// tls.rs:167-171 — pinning 路径
+if config.tls_sni_override.is_some() {
+    tls_config.enable_sni = true;                    // 同样只是开关，不设主机名
+}
+```
+
+```rust
+// ws_client.rs:361-363 — WS 路径，同样问题
+if config.tls_sni_override.is_some() {
+    builder = builder.tls_sni(true);
+}
+```
+
+注释里还残留 `reqwest 0.12` 字样，但仓库实际已升级到 **reqwest 0.13**（`catcher-http/Cargo.toml:30`、`catcher-ws/Cargo.toml:29`），注释过时。
+
+reqwest 0.13 没有提供"用与 URL host 不同的主机名做 SNI"的直接 API —— SNI 的 `ServerName` 在连接时由 URL authority 决定，`ClientConfig` 层无法覆写单连接的 ServerName。
+
+## 修复方案与工作量
+
+### 方案 A（推荐，小）：显式拒绝，消除静默失效
+在 Rust 路径构建时，若 `tls_sni_override.is_some()` 直接返回 `CatcherError::InvalidConfig("tls_sni_override is not supported on the native transport")`。
+
+- **工作量**：小（~3 处各 2-3 行 + 单测）。
+- **影响范围**：不改类型、不改绑定签名。行为变化 —— 之前静默忽略的调用方现在会在构建客户端时收到明确错误，便于及早发现。
+- **权衡**：把"假装支持"换成"诚实不支持"，是这 4 个问题里性价比最高的。
+
+### 方案 B（中）：用 resolve + host 改写模拟覆写
+把请求 URL 的 host 改成 SNI 主机名，再用 `reqwest::ClientBuilder::resolve(sni_host, real_addr)` 把它指向真实目标 IP（域前置式）。
+
+- **工作量**：中。
+- **影响范围**：会**连带改变 `Host` 请求头和证书校验对象**，语义与"仅覆写 SNI"不同，不通用；对 WS 同样要改 URL，复杂度高。不推荐作为通用实现。
+
+### 方案 C（大）：自定义 rustls Connector
+绕过 reqwest 的连接层（或直接基于 hyper + 自定义 `tokio-rustls` connector），在建立 TLS 时显式传入自定义 `ServerName`。
+
+- **工作量**：大（需重写 HTTP 与 WS 的连接建立路径，且与现有 pinning/代理/DNS 注入逻辑交织）。
+- **影响范围**：连接层重构，回归风险高。仅当确有强需求（如必须支持 SNI 与 Host 分离的企业代理）才值得。
+
+## 推荐
+
+先做**方案 A**（止血，让行为诚实），并把 TS 路径的能力差异写进文档。是否需要方案 B/C 取决于是否有真实客户场景要求 SNI 与 URL host 分离 —— 目前无证据，暂不投入。
+
+## 影响范围小结
+
+| 维度 | 评估 |
+|------|------|
+| 是否大改 | 方案 A 否（局部）；方案 C 是（连接层重构） |
+| 跨语言绑定 | 类型字段已在所有绑定暴露；方案 A 不动绑定，仅 Rust 侧校验 |
+| 破坏性 | 方案 A 是行为变化（静默→报错），非编译破坏 |
+| 数据/安全相关 | 是 —— SNI 覆写常用于证书校验与流量分流，静默失效可能导致错误的安全预期 |
+
+## 验证建议
+
+- 单测：构造带 `tls_sni_override` 的配置，断言方案 A 下 `HttpTransport::new` / WS 客户端构建返回 `InvalidConfig`。
+- 若实现真实覆写：用本地 TLS server 抓 ClientHello，断言 SNI 字段等于覆写值（而非 URL host）。
+- 跑 `cargo clippy --workspace --all-targets -- -D warnings`、`pnpm typecheck`。
+
+## 关联
+
+- `packages/catcher-http-ts/src/agent/shared-agent.ts:147-148` — TS 路径正确实现（`servername`），可作为行为对齐参考
+- [025-ws-missing-tls12-feature.md](./025-ws-missing-tls12-feature.md) — 同属 TLS 配置类问题
+- reqwest `tls_sni` 文档：https://docs.rs/reqwest/0.13/reqwest/struct.ClientBuilder.html#method.tls_sni

--- a/docs/issues/029-network-path-id-dead-field.md
+++ b/docs/issues/029-network-path-id-dead-field.md
@@ -1,0 +1,85 @@
+# Bug: `networkPathId` 是死字段 —— 配置项被接受但从未被任何逻辑读取
+
+**严重程度**: 🟢 Low — 无功能损害，但是误导性 API 表面：调用方以为设置它能触发网络变化处理，实则完全无效
+
+**状态**: Fixed — 采用方案 A：从 Rust 配置、测试及全部绑定（TS / Dart）移除 `network_path_id` / `networkPathId`；网络切换恢复统一由 `networkChanged()` 承担
+
+**影响包**: `catcher-http`、`catcher-ws`、全部绑定（napi / TS / Dart）
+
+**位置**:
+- `packages/catcher-http/src/types/http.rs:207`（定义）、`:239`（默认值）
+- `packages/catcher-ws/src/types/ws.rs:239`（定义）、`:278`（默认值）
+- 绑定：`catcher-core-ts/src/types.ts:154,297`、`catcher-napi-http/ts/types.ts:177`、`catcher-napi-ws/ts/types.ts:128`、`catcher_core/lib/src/http_client.dart:1109`、`catcher_core/lib/src/ws_client.dart:425`
+
+---
+
+## 现象
+
+`HttpClientConfig` 和 `WsClientConfig` 都有 `network_path_id: Option<String>` 字段，并在所有绑定层暴露。字段语义暗示："宿主传入一个网络路径标识（如 `wifi` / `cellular` / `vpn-on`），当它变化时库自动重建连接、刷新 DNS"。
+
+实际上：**catcher-http / catcher-ws 的运行逻辑中没有任何地方读取这个字段**。
+
+```
+$ grep -rn "network_path_id" packages --include="*.rs"
+packages/catcher-http/src/types/http.rs:207:    pub network_path_id: Option<String>,   # 定义
+packages/catcher-http/src/types/http.rs:239:            network_path_id: None,          # 默认
+packages/catcher-ws/src/types/ws.rs:239:    pub network_path_id: Option<String>,     # 定义
+packages/catcher-ws/src/types/ws.rs:278:            network_path_id: None,            # 默认
+packages/catcher-ws/src/transport/ws_client.rs:1620:  ...network_path_id...               # 仅一个断言测试
+```
+
+设置它**不触发任何行为**：不重建连接池、不清 DNS、不重置熔断器。
+
+## 根因
+
+字段在 PR #14 引入，意图是承载"网络路径变化 → 库自动重建"的语义。但 PR #13 已经通过显式 API `networkChanged()` 实现了完整的网络切换恢复（清 DNS、热替换连接池、重置熔断器）。`networkChanged()` 是更明确、更可控的机制，于是 `network_path_id` 的预期职责被它完全覆盖，字段沦为没有读取方的"装饰"。
+
+它给了 API 使用者"已经在处理网络变化"的**错觉**，而真正的开关是 `networkChanged()`。
+
+## 修复方案与工作量
+
+### 方案 A（推荐）：移除字段
+从 core 配置结构、http/ws 配置、以及全部绑定类型中删除 `network_path_id` / `networkPathId`。
+
+- **工作量**：中-小（纯机械删除，但跨 Rust + 3 套绑定 + 文档，触及面较广）。
+- **破坏性**：
+  - JSON 反序列化层**不破坏** —— 仓库未使用 `#[serde(deny_unknown_fields)]`（已确认），旧调用方继续传 `network_path_id` 会被静默忽略。
+  - 强类型绑定（TS / Dart）层面是 **source-breaking**：显式构造该字段的代码需删除。但因字段是 optional 且无行为，实际使用者预计极少。
+- **影响范围**：见下表。
+
+### 方案 B：补上语义，让字段名副其实
+在客户端持有"上次 network_path_id"，每次请求/重连前比较，若变化则内部调用 `network_changed()`。
+
+- **工作量**：中（需在 HttpTransport/WsClient 增加状态 + 比较逻辑 + 测试）。
+- **权衡**：与显式 `networkChanged()` API **功能冗余**，等于提供两套做同一件事的入口，增加维护面与语义歧义。除非明确想支持"声明式 path id"风格，否则不建议。
+
+### 方案 C（最小）：保留但标注 reserved
+在字段上加 `#[doc]` 注明"当前未实现，预留；如需网络切换恢复请调用 `networkChanged()`"。
+
+- **工作量**：最小（仅文档注释）。
+- **权衡**：零风险，但保留了一个长期没人实现的"占位字段"，技术债不消失。
+
+## 推荐
+
+**方案 A 移除**。理由：`networkChanged()` 已是更好的机制，保留一个永远不生效的同义字段只会持续误导调用方。若团队对未来"声明式 path id"有明确规划，则退而取**方案 C**（显式标注 reserved），但不要维持现状（既不实现也不标注）。
+
+## 影响范围小结
+
+| 维度 | 评估 |
+|------|------|
+| 是否大改 | 否 —— 删除/标注为主，无逻辑重写 |
+| 跨语言绑定 | 是 —— Rust + TS(core/napi×2) + Dart(http/ws) 共 ~9 处 |
+| 破坏性 | JSON 层不破坏（无 deny_unknown_fields）；强类型绑定 source-breaking（预计影响极小） |
+| 运行时风险 | 无 —— 字段当前无任何行为 |
+
+## 验证建议
+
+- 方案 A：删除后 `cargo build --workspace`、`pnpm typecheck`、`dart analyze` 全绿；grep 确认无残留读取点。
+- 删除 `ws_client.rs:1620` 附近引用该字段的断言测试。
+- 文档（`docs/user-manual/resilience.md` 等）若提及该字段需同步移除。
+
+## 关联
+
+- [027-proxy-vpn-network-compatibility-research.md](./027-proxy-vpn-network-compatibility-research.md) — 字段引入背景
+- `networkChanged()` API（PR #13）—— 真正承载网络切换恢复的机制，本字段的替代者
+- [030-network-changed-inflight-requests.md](./030-network-changed-inflight-requests.md) — 同属 `networkChanged()` 语义范畴

--- a/docs/issues/030-network-changed-inflight-requests.md
+++ b/docs/issues/030-network-changed-inflight-requests.md
@@ -1,0 +1,87 @@
+# Bug: `networkChanged()` 不恢复在途请求，且注释「飞行中的请求不受影响」言过其实
+
+**严重程度**: 🟡 Medium — 注释误导 + 功能缺口：网络切换后正在进行的长请求/流式下载仍会卡在旧半开连接上直到自身超时
+
+**状态**: Fixed — 修正 `http_client.rs` 误导注释，并在 `resilience.md` 补充 `networkChanged()` + `cancelAll()` 组合用法（方案 A）；未引入 API 变化
+
+**影响包**: `catcher-http`（核心）；`catcher-ws` 行为类似需一并评估
+
+**位置**:
+- `packages/catcher-http/src/transport/http_client.rs:140`（误导注释）
+- `packages/catcher-http/src/transport/http_client.rs:131-167`（`network_changed` 实现）
+- `packages/catcher-http/src/transport/http_client.rs:497`（`execute_stream`，已支持 `CancellationToken`）
+- `packages/catcher-http/src/transport/http_client.rs:425`（`cancel_all`，已存在）
+
+---
+
+## 现象
+
+`networkChanged()` 通过热替换 `RwLock<Client>` 丢弃整个旧连接池。这只让**之后发起的新请求**走新连接，**对调用时正在进行中的请求无效**：
+
+- 一个正在 `execute_stream` 流式下载的请求，已捕获旧 client 的连接（`http_client.rs:124` 的 `client()` 克隆在请求开始时取一次），会继续阻塞在网络切换后变成半开的 socket 上，直到它自己的 `response_timeout_ms` 超时。
+- 非流式但耗时较长的请求同理。
+
+而代码注释却写：
+
+```rust
+// http_client.rs:140
+/// 飞行中的请求不受影响：其内部重试会自动建立新连接。
+```
+
+这句只在**配了 `retry` 且失败可重试**时部分成立 —— 流式下载、未配重试、或正卡在读取阶段的请求都不会自动恢复。注释把"无能为力"描述成了"不受影响"，会让使用者误以为 `networkChanged()` 已覆盖在途请求。
+
+## 根因
+
+连接池热替换是"换池子"，不是"中断正在用旧池子的人"。在途请求持有旧 `ClientWithMiddleware` 的克隆（这本身是正确的设计 —— 避免请求中途被抽走连接），因此不受新池子影响，也就得不到主动恢复。库目前**没有把已有的取消能力接入 `network_changed()`**。
+
+值得注意：恢复在途请求所需的原材料**已经齐全**：
+- `execute_stream` 已接受 `CancellationToken`（`:497`）
+- `cancel_all()` 已实现，可取消所有 `pending_requests`（`:425`）
+
+只是 `network_changed()` 没有调用它们。
+
+## 修复方案与工作量
+
+### 必做（tiny）：修正注释
+把 `:140` 的注释改为如实描述：连接池热替换只影响新请求；在途请求（尤其流式下载）不会被主动中断，需调用方配合 `cancelAll()` 或等待其自身超时。
+
+- **工作量**：极小（1 处注释 + 同步文档 `resilience.md`）。
+
+### 方案 A（推荐，小）：文档化组合用法
+不改 API，在用户手册中明确：「若希望网络切换时连同在途请求一起恢复，请调用 `networkChanged()` 后再调用 `cancelAll()`（在途请求会失败/重试，由上层决定是否重发）」。
+
+- **工作量**：小（纯文档）。
+- **影响范围**：零代码风险，零 API 变化。
+- **权衡**：把决策权留给调用方（取消在途请求是有副作用的行为，不应默认发生）。
+
+### 方案 B（小-中）：给 `network_changed` 增加可选的在途取消
+新增带参签名，例如 `network_changed(cancel_inflight: bool)`（默认 `false`），为 `true` 时在重建连接池后调用 `cancel_all()`。
+
+- **工作量**：小-中（Rust 侧复用现成 `cancel_all`；但参数要贯通 C ABI / napi / UniFFI / Dart 四套绑定）。
+- **影响范围**：API 签名变化 → 跨全部绑定（见 PR #13 中 `networkChanged()` 的暴露面）。需保持向后兼容（默认 false / 重载）。
+- **权衡**：把"是否取消在途"做成显式开关，比让调用方手动两步调用更内聚，但扩大了绑定改动面。
+
+## 推荐
+
+**必做修注释 + 方案 A 文档化**先行（零风险，立即消除误导）。若后续有客户明确反馈"网络切换时希望一键连在途请求一起恢复"，再上**方案 B**（默认 `false`，避免改变现有语义）。
+
+## 影响范围小结
+
+| 维度 | 评估 |
+|------|------|
+| 是否大改 | 否 —— 修注释/文档为主；方案 B 也只是复用现成 `cancel_all` |
+| 跨语言绑定 | 修注释/文档：无；方案 B：是（4 套绑定签名） |
+| 破坏性 | 方案 A 无；方案 B 用默认参数可保持兼容 |
+| WS 是否同样问题 | 需评估 —— WS 的 `network_changed()` 立即丢连接并重连，半开 send 已被 `send_timeout_ms` 兜底，缺口比 HTTP 小，但长 streaming 接收同样值得检查 |
+
+## 验证建议
+
+- 复现：发起一个慢响应/流式请求 → 中途调用 `networkChanged()` → 断言该请求仍在等待（证明缺口），调用 `cancelAll()` 后立即结束（证明组合有效）。
+- 方案 B：单测断言 `network_changed(true)` 后在途请求被取消、新请求正常（可参考 `ns03_cancel_all_then_new_requests_work`，`http_client.rs:1320`）。
+
+## 关联
+
+- PR #13 `networkChanged()` 实现
+- `http_client.rs:425` `cancel_all` / `:446` `cancel_request`（N-03 单请求取消能力）
+- [017-ffi-stream-cancel-broken.md](./017-ffi-stream-cancel-broken.md) — 流式取消相关历史问题
+- [029-network-path-id-dead-field.md](./029-network-path-id-dead-field.md)

--- a/docs/issues/031-proxy-dns-relies-on-reqwest-internal-behavior.md
+++ b/docs/issues/031-proxy-dns-relies-on-reqwest-internal-behavior.md
@@ -1,0 +1,74 @@
+# Bug: 代理下「目标域名不被本地解析」的正确性依赖 reqwest 未文档化的内部行为，仅靠测试兜底
+
+**严重程度**: 🟢 Low-Medium — 当前行为正确，但属于隐性脆弱点：reqwest 升级若改变内部行为，目标域名可能被本地解析并以 IP 泄漏给代理，破坏 Clash/VPN 的域名分流，且无防御性代码、唯一护栏是 feature-gated 的集成测试
+
+**状态**: Fixed — 采用方案 A：在 HTTP/WS resolver 注入处、`Cargo.toml`、CI 与 arch 文档显式记录对 reqwest 内部行为的依赖与「升级须重跑 proxy_dns_behavior_test」规则（CI 默认 feature 已覆盖该测试）
+
+**影响包**: `catcher-http`、`catcher-ws`
+
+**位置**:
+- `packages/catcher-http/src/transport/http_client.rs:198-205`（resolver 注入）+ `:207-222`（proxy 应用）
+- `packages/catcher-ws/src/transport/ws_client.rs:378-399`（同上）
+- `packages/catcher-http/tests/proxy_dns_behavior_test.rs`、`packages/catcher-ws/tests/proxy_dns_behavior_test.rs`（唯一护栏）
+
+---
+
+## 现象
+
+PR #15 的核心正确性保证是：**当配置了代理时，目标域名必须交给代理远端解析，绝不能在本地解析成 IP 后再交给代理**（否则 Clash 的 fake-ip / 域名分流会失效，正是移动端故障的根因）。
+
+这个保证目前由两件事共同维持：
+1. `socks5://` → `socks5h://` 归一化（`ProxyConfig::transport_url`，确实强制远端解析）；
+2. **reqwest 在请求走代理时不会调用自定义 `dns_resolver`** —— 因此即便 Catcher DNS（`DnsMode::Catcher`）的自定义 resolver 被全局注入，代理路径上的目标域名也不会被它本地解析。
+
+第 2 点是隐式依赖：代码把 resolver 无条件注入到 `ClientBuilder`，然后另外应用 proxy，**没有任何地方显式声明"代理时不要用这个 resolver 解析目标 host"**。它能工作，纯粹因为 reqwest 当前的内部实现恰好如此。
+
+## 根因
+
+resolver 必须为**直连 / `no_proxy` 命中**的 host 服务（这些走本地解析是对的），因此**不能简单地"配了代理就不注入 resolver"** —— 那会破坏 no_proxy 旁路。于是代码选择了"全局注入，依赖 reqwest 对代理路径自动跳过 resolver"的隐式策略。
+
+风险点：
+- 这一行为**未见于 reqwest 的稳定 API 文档承诺**，是实现细节。reqwest 0.13 → 未来版本若调整代理与自定义 resolver 的交互顺序，目标域名可能被本地解析，静默回归到"IP 泄漏给代理"的故障。
+- 唯一的回归护栏是 `proxy_dns_behavior_test`（协议级探针断言代理收到的是域名而非 IP）。但这些测试 **gated on `hickory-dns` feature**，若 CI 的默认 feature set 不含它，升级 reqwest 时不会自动触发该测试。
+
+## 修复方案与工作量
+
+### 方案 A（推荐，小）：测试 + CI + 文档加固
+1. 确保 `proxy_dns_behavior_test`（HTTP 与 WS）在 **CI 的默认/相关 feature set 下实际运行**（含 `hickory-dns`），而非仅本地手动 `--ignored`。
+2. 在 reqwest 依赖处用注释 + 文档（如 `docs/arch-rs/04-transport.md`）**显式记录**："代理路径目标域名不本地解析"依赖 reqwest 内部行为，**升级 reqwest 必须重跑 proxy_dns_behavior_test**。
+3. 可选：在 `Cargo.toml` 对 reqwest 采用谨慎的版本约束，升级走显式评审。
+
+- **工作量**：小（CI 配置 + 注释/文档 + 可能的版本约束）。
+- **影响范围**：无运行时改动，纯流程/测试加固。
+
+### 方案 B（中-大）：显式自定义 Connector，不依赖隐式行为
+实现一个包裹层，在请求分流时显式区分"走代理（交域名给代理）"与"直连（用 Catcher resolver）"，把正确性从 reqwest 内部行为中解耦出来。
+
+- **工作量**：中-大（需介入 reqwest 连接层或自建 connector，与现有 TLS/pinning/proxy 逻辑交织）。
+- **影响范围**：连接层改动，回归风险显著高于收益。
+- **权衡**：当前行为已正确，方案 B 主要买"对 reqwest 升级的免疫"，收益有限，**不建议**除非未来 reqwest 真的破坏了该行为。
+
+## 推荐
+
+**方案 A**。这是一个"加固护栏"而非"修 bug"的工作：把隐式依赖显式化（文档 + CI 必跑的测试），让 reqwest 升级时回归能被立即捕获。方案 B 的连接层重构在没有实际破坏发生前不划算。
+
+## 影响范围小结
+
+| 维度 | 评估 |
+|------|------|
+| 是否大改 | 否（方案 A）；是（方案 B 连接层重构） |
+| 当前是否有 bug | 否 —— 行为正确，问题是「脆弱 + 缺护栏」 |
+| 跨语言绑定 | 无（纯 Rust + CI） |
+| 触发条件 | reqwest 升级改变代理 × 自定义 resolver 交互；或 CI 不跑 hickory-dns 测试时的静默回归 |
+
+## 验证建议
+
+- 确认 `proxy_dns_behavior_test` 在 CI workflow 中以含 `hickory-dns` 的 feature 运行，并在 reqwest 升级 PR 上强制通过。
+- 测试本身质量已达标：`catcher-test-support` 的 `Socks5Probe` 在协议字节层区分 `Domain(0x03)` vs `Ip(0x01)`，`HttpProxyProbe` 区分 `CONNECT authority` vs 转发 URI，能真正证明远端解析。复用即可。
+
+## 关联
+
+- PR #15 `fix: support proxy dns behavior across http and ws`
+- [026-mobile-proxy-vpn-clash.md](./026-mobile-proxy-vpn-clash.md)、[027-proxy-vpn-network-compatibility-research.md](./027-proxy-vpn-network-compatibility-research.md)
+- `packages/catcher-test-support/src/socks5.rs`、`http_proxy.rs` — 协议级探针
+- `ProxyConfig::transport_url`（`catcher-core/src/types/network.rs:106-115`）— socks5→socks5h 归一化

--- a/docs/issues/032-ws-pin-sha256-not-supported.md
+++ b/docs/issues/032-ws-pin-sha256-not-supported.md
@@ -1,0 +1,102 @@
+# Feature gap: WS 尚未实现 `pin_sha256` 证书固定（HTTP 已支持）
+
+**类型**: 能力缺口（feature gap），**非 bug** —— WS 从未声称支持，代码 fail-closed 显式报错（不静默假装生效，无安全降级、无数据损坏）。归属与 `native-layer-capability-gaps.md` / `api-gap-features.md` 同类。
+
+**优先级**: 🟡 P1–P2（取决于是否有 WS 上的证书固定真实需求）
+
+**状态**: Open（未实现）
+
+> 为何不是 bug：bug 是"承诺了 A 却做了 B / 误导"。WS 对 `pin_sha256` 既没承诺也没静默忽略，
+> 而是明确拒绝并返回 `not supported yet`，行为诚实。它是"能力尚未实现"。
+> 唯一带 bug 色彩的次要瑕疵：共享的 `TlsConfig` 类型暴露了该字段却无类型层标注 ——
+> 属 API 一致性瑕疵，可由方案 A 顺带消除。
+
+**影响包**: `catcher-ws`、`catcher-core`（共享类型）、绑定（napi-ws TS、Dart 共享 TlsConfig）
+
+**位置**:
+- `packages/catcher-ws/src/transport/ws_client.rs:296-304`（WS 硬报错）
+- `packages/catcher-http/src/transport/tls.rs:26-34`（HTTP 入口分流）+ `tls.rs:110-176` `build_tls_with_pinning`
+- `packages/catcher-http/src/transport/tls_pinning.rs`（`PinningVerifier` 实现，仅在 catcher-http crate）
+- `packages/catcher-core/src/types/network.rs:60`（`pin_sha256` 字段，HTTP/WS 共享）
+- 绑定暴露：`catcher-napi-ws/ts/types.ts:75`、`catcher-napi-http/ts/types.ts:58`、`catcher-core-ts/src/types.ts:72`、`catcher_core/lib/src/http_client.dart:979`（Dart `TlsConfig` 类，WS 复用同一类）
+
+---
+
+## 现象
+
+`TlsConfig.pin_sha256`（SHA-256 公钥指纹固定，防 MITM）是 HTTP 与 WS **共享的同一个类型字段**。
+
+- **HTTP**：完整实现。`build_tls_config` 检测到非空 `pin_sha256` 时分流到 `build_tls_with_pinning`，构建带 `PinningVerifier` 的 `rustls::ClientConfig` 并经 `use_preconfigured_tls` 注入。证书固定真实生效。
+- **WS**：`build_reqwest_tls_config` 开头即拦截：
+
+```rust
+// ws_client.rs:296-304
+if config
+    .pin_sha256
+    .as_ref()
+    .is_some_and(|pins| !pins.is_empty())
+{
+    return Err(CatcherError::InvalidConfig(
+        "ws tls.pin_sha256 is not supported yet".into(),
+    ));
+}
+```
+
+结果：用户用同一份 `TlsConfig` 配了证书固定，HTTP 客户端能建连，**WS 客户端在构建/建连那一刻直接失败**。该字段在 `napi-ws` 的 TS 类型、以及 Dart 共享的 `TlsConfig` 类上都暴露，用户没有任何静态提示表明 WS 不支持它，只能在运行时撞墙。
+
+> 同类情况：`client_identity_pfx` 在 WS 也被拒绝（`ws_client.rs:347-352`），属于同一种"共享类型、能力分裂"的模式，可一并考虑。
+
+## 根因
+
+1. PR #14 把 WS 迁移到 reqwest 后，HTTP 与 WS 都基于 `reqwest + rustls`，但 pinning 的实现（`PinningVerifier` + `build_tls_with_pinning`）只落在 **catcher-http crate 内部**，没有抽取到共享层。
+2. WS 不能反向依赖 catcher-http，于是无法复用该实现，只能先用一个 "not supported yet" 的占位报错挡住。
+3. 类型却是共享的（`catcher-core::types::network::TlsConfig`），造成"类型承诺了 WS 运行时拒绝的能力"这一漏抽象（leaky abstraction）。
+
+技术上 WS **完全有条件**支持 pinning：它也走 reqwest + rustls（`reqwest/rustls` feature），同样可以用 `use_preconfigured_tls(带 PinningVerifier 的 rustls config)`。唯一障碍是 `PinningVerifier` 的归属与依赖布局。
+
+## 修复方案与工作量
+
+### 方案 A（最低限度，小）：类型层 + 文档标注 WS 不支持
+在 napi-ws TS 类型、Dart 共享 `TlsConfig`（或单独的 WS 文档段）明确标注 `pin_sha256` / `client_identity_pfx` 在 WS 上不支持，让用户在编码阶段就知道，而不是运行时才发现。
+
+- **工作量**：小（注释 + 文档）。
+- **影响范围**：无运行时改动。
+- **权衡**：止血、消除"以为支持"的误解，但 WS 仍无证书固定能力。与 issue #028 的处理思路一致。
+
+### 方案 B（彻底修，中）：抽取 pinning 到共享 crate，WS 真正支持
+1. 把 `PinningVerifier`（+ `build_tls_with_pinning` 的核心逻辑）从 catcher-http 抽到共享 crate（`catcher-core` 或新建 `catcher-tls`）。
+2. 给 catcher-ws 增加 `rustls` / `rustls-pki-types` / `sha2` / `webpki-roots` 直接依赖（目前只通过 `reqwest/rustls`、`yawc/rustls-ring` 间接引入）。
+3. WS 的 `build_reqwest_tls_config` 在 `pin_sha256` 非空时走 `use_preconfigured_tls`，与 HTTP 对齐。
+4. 补 WS pinning 单测（正确指纹放行 / 错误指纹拒绝）。
+
+- **工作量**：中（共享抽取 + WS 接线 + 依赖调整 + 测试），非大重构。
+- **影响范围**：catcher-http（迁出 PinningVerifier，保持对外行为不变）、catcher-ws（新增依赖与逻辑）、共享 crate。
+- **权衡**：彻底消除类型不一致，WS 获得与 HTTP 对等的安全能力。
+
+## 推荐
+
+取决于是否有 **WS 上的证书固定真实需求**：
+- 当前无需求 → 先做**方案 A**（标注 + 文档），把"运行时撞墙"降级为"编码期可见"。
+- 有需求 → 直接做**方案 B**，顺带把 `client_identity_pfx` 的 WS 支持一并评估。
+
+## 影响范围小结
+
+| 维度 | 评估 |
+|------|------|
+| 是否大改 | 否 —— 方案 A 仅文档/注释；方案 B 为中等（共享抽取 + 接线） |
+| 跨语言绑定 | 方案 A 触及 napi-ws TS / Dart 注释；方案 B 主要 Rust 侧 |
+| 安全性质 | **fail-closed**：WS 不会"假装固定成功"，而是直接建连失败，不存在静默安全降级 |
+| 触发条件 | 仅当用户实际为 WS 配置了非空 `pin_sha256`（或 `client_identity_pfx`） |
+
+## 验证建议
+
+- 方案 B：WS 单测 —— 正确公钥指纹的本地 wss server 可连；篡改指纹后建连被拒。
+- `cargo clippy --workspace --all-targets -- -D warnings`、`pnpm typecheck`。
+- 回归：确认 catcher-http 的现有 pinning 测试（迁出 PinningVerifier 后）仍通过。
+
+## 关联
+
+- [025-ws-missing-tls12-feature.md](./025-ws-missing-tls12-feature.md) — WS TLS 配置类历史问题
+- [028-tls-sni-override-noop-rust-path.md](./028-tls-sni-override-noop-rust-path.md) — 同属"共享 TlsConfig 类型、原生 transport 能力不全"
+- PR #14 review MAJOR M2（"WS TLS pinning 与 HTTP 分裂"）—— 本 issue 即该发现的独立化
+- `catcher-http/src/transport/tls_pinning.rs` — 可被抽取复用的 `PinningVerifier`

--- a/docs/issues/033-quality-test-flake-and-ci-fail-fast.md
+++ b/docs/issues/033-quality-test-flake-and-ci-fail-fast.md
@@ -1,0 +1,80 @@
+# Bug: `q05_subscribe_multiple` 时序 flake，且 CI 缺 `--no-fail-fast` 导致单个 flake 掩盖整个测试套件
+
+**严重程度**: 🟡 Medium — 不是产品 bug，但严重影响 CI 可信度：CI 长期为红，且红的真因掩盖了后续所有测试是否通过
+
+**状态**: Fixed
+
+**影响包**: `catcher-ffi`（测试）、CI（`.github/workflows/ci.yml`）
+
+**位置**:
+- `packages/catcher-ffi/tests/quality_test.rs:143-183`（`q05_subscribe_multiple`）
+- `.github/workflows/ci.yml`（`cargo test --workspace`）
+
+---
+
+## 现象
+
+1. CI 的 `rust-check` job 长期失败。排查发现唯一失败的测试是 `q05_subscribe_multiple`（`quality_test.rs:177` 的断言），自 ≥v0.3.12 起间歇性红。
+2. 更严重的连带问题：`cargo test --workspace` **未加 `--no-fail-fast`**，默认会在**第一个失败的测试二进制处停止**。由于 `catcher-ffi` 的 quality_test 在 catcher-ws 等之前运行，一旦 `q05` flake，cargo 直接 bail，**后续整个套件（含 catcher-ws lib 测试、proxy_dns_behavior 等）根本不执行**。
+
+对比两次 CI 运行可证实：
+- `849187d`（PR #13 合并，q05 恰好通过）→ CI 绿，且日志中 `connect_stream_uses_dns_host_mapping ... ok`、其余套件正常跑完。
+- `15b1233`（PR #15 合并，q05 flake）→ CI 红，日志中**只有 q05 失败**，之后所有测试二进制**未出现**（被 fail-fast 截断）。
+
+## 根因
+
+### q05 的 flake
+
+`q05_subscribe_multiple` 创建两个独立订阅（`sub1` / `sub2`），都以 1000ms 间隔探测 `https://www.example.com`，每次**真实网络探测完成后**才触发一次回调。测试在 2s 后退订 `sub1`、再 1s 后断言：
+
+```rust
+assert!(count2 >= count1, "sub2 should have at least as many callbacks as sub1");
+```
+
+这是一个**跨 prober 的相对速度比较**。两个订阅的回调次数取决于各自网络探测的实际延迟，是非确定的：若 `sub2` 的探测恰好比 `sub1` 慢（或第 N 次探测仍在飞行中），就会出现 `count2 < count1`，断言失败。即测试用"谁的回调多"这一脆弱代理，去验证"多订阅独立工作"。
+
+### CI fail-fast 掩盖
+
+`cargo test` 默认 fail-fast：第一个失败的测试二进制就让整条命令停止。单个 flaky 测试因此能掩盖后续所有测试的真实状态 —— CI 看似"红在 q05"，实则后面的测试**根本没机会运行**，掩盖了真实覆盖。
+
+## 修复
+
+### 1. q05 改为按生命周期断言，不比较两个 prober 的相对速度
+保留测试意图（多订阅独立 + 退订只影响自身），但改用**每个订阅各自单调**的判定（与稳定的 `q03` 同语义）：
+
+```rust
+unsafe { quality::catcher_quality_unsubscribe(sub1) };
+let count1_at_unsub = state1.lock().unwrap().count;
+let count2_at_unsub = state2.lock().unwrap().count;
+tokio::time::sleep(Duration::from_secs(2)).await;
+let count1_final = state1.lock().unwrap().count;
+let count2_final = state2.lock().unwrap().count;
+// sub1 退订后不再新增回调
+assert_eq!(count1_final, count1_at_unsub, "sub1 退订后不应再收到回调");
+// sub2 不受 sub1 退订影响，计数单调不减
+assert!(count2_final >= count2_at_unsub, "sub2 不应受 sub1 退订影响");
+```
+
+新断言不依赖网络探测的相对快慢，因而确定、稳定（本地连跑 3 次 + 全套件 5/5 通过）。
+
+### 2. CI 加 `--no-fail-fast`
+`cargo test --workspace --no-fail-fast`，让一个失败测试不再截断后续套件，CI 能反映全部测试的真实状态。
+
+## 影响范围小结
+
+| 维度 | 评估 |
+|------|------|
+| 是否大改 | 否 —— 改一个测试断言 + CI 一行 |
+| 是否产品 bug | 否 —— 纯测试健壮性与 CI 配置 |
+| 价值 | 高 —— 恢复 CI 可信度，避免单 flake 掩盖整套件 |
+
+## 验证
+
+- `cargo test -p catcher-ffi --test quality_test` —— 5 passed（q02/q03/q04/q05/q07）。
+- q05 连续 3 次运行均通过。
+
+## 关联
+
+- [023-evaluate-quality-race-panic.md](./023-evaluate-quality-race-panic.md) — 网络质量相关历史问题
+- 由 #032/`connect_stream` 测试排查衍生：发现 CI 实际未跑到 catcher-ws 套件，根因即本 issue 的 fail-fast。
+- `connect_stream_uses_dns_host_mapping`（macOS 沙箱本地失败、Linux CI 通过）的环境特异性结论，依赖本 issue 修复后 CI 能完整跑完套件来持续验证。

--- a/docs/issues/034-ffi-callback-uaf-test-and-destroy-asymmetry.md
+++ b/docs/issues/034-ffi-callback-uaf-test-and-destroy-asymmetry.md
@@ -1,0 +1,80 @@
+# Bug: FFI 回调测试 use-after-free（整套并行跑时 SIGSEGV），并暴露 HTTP destroy 不抑制在途回调的不对称
+
+**严重程度**: 🟡 Medium — 测试侧 UAF 导致 CI 整套并行运行时间歇 SIGSEGV（被 #033 的 fail-fast 长期掩盖）；并连带暴露一处产品契约不对称（待评估）
+
+**状态**: Fixed（测试侧 + 产品侧 HTTP/SSE destroy 已与 WS 对齐）
+
+**影响包**: `catcher-ffi`（测试）；观察项涉及 `catcher-http`（`ffi/http_ffi.rs`）
+
+**位置**:
+- `packages/catcher-ffi/tests/http_test.rs:301`（`make_result_cell`）、`:635`（`make_events_cell`）
+- `packages/catcher-ffi/tests/quality_test.rs:18`（`make_callback_state`）
+- `packages/catcher-http/src/ffi/http_ffi.rs:50`（全局 `runtime()`）、`:128`（`catcher_http_client_destroy`）、`:161/280/361/580`（`runtime().spawn` 回调任务）
+
+---
+
+## 现象
+
+`cargo test -p catcher-ffi --test http_test` **单线程跑全过**，但**默认并行**整套跑时间歇性 **SIGSEGV**（PR #13 描述记录为"`h11_cancel_all_with_per_request` 附近崩溃，FFI 回调 + 全局 runtime 跨测试污染"）。由于 CI 未加 `--no-fail-fast`（见 [#033](./033-quality-test-flake-and-ci-fail-fast.md)），它长期被更靠前的 quality_test flake 掩盖，从未在 CI 暴露。
+
+## 根因（测试侧 UAF）
+
+FFI 用一个**全局 tokio runtime**（`http_ffi.rs:50`）执行请求，请求完成时在该 runtime 上**回调** `user_data`。`catcher_http_client_destroy`（`:128`）只做 `REGISTRY.remove(id)`，**不取消在途 spawn 任务、也不阻止其回调**（spawn 时已 clone 了 `Arc<HttpTransport>`，任务持有它直到自身结束）。
+
+测试侧把回调目标这样传入：
+
+```rust
+let cell = Arc::new(Mutex::new(None::<String>));
+let ptr = Arc::as_ptr(&cell) as *mut c_void;   // user_data 指向 Arc 内部数据
+```
+
+测试函数结束时 `cell`（Arc）被 drop → Mutex 释放。但若某个在途/被取消请求的回调在**测试返回后**才在全局 runtime 上触发（并行时多个测试时序交叠，极易发生），它会通过 `user_data` 解引用**已释放的内存** → use-after-free → SIGSEGV。单线程时各测试间的 `sleep` 恰好把回调排空，故不崩。
+
+同样的模式存在于 `quality_test.rs` 的 `make_callback_state`（周期性探测回调 + abort 对同步回调有竞态窗口）。
+
+## 修复（测试侧）
+
+让 `user_data` 指向的内存**在进程生命周期内始终有效**——用 `Box::leak` 泄漏每个测试的回调状态，取代 `Arc::as_ptr`：
+
+```rust
+fn make_result_cell() -> (&'static Mutex<Option<String>>, *mut c_void) {
+    let leaked: &'static Mutex<Option<String>> = Box::leak(Box::new(Mutex::new(None::<String>)));
+    let ptr = leaked as *const Mutex<Option<String>> as *mut c_void;
+    (leaked, ptr)
+}
+```
+
+延迟回调因此始终写入有效内存，UAF 被彻底消除。每个测试泄漏一个小 Mutex，在测试进程内可忽略。`make_events_cell`、`quality_test::make_callback_state` 同样处理。
+
+> 这同时也与正确的 FFI 契约一致：**宿主必须在回调可能触发的整个生命周期内保持 `user_data` 有效**。旧测试在 destroy 后立刻释放 `user_data`，本就违反该契约。
+
+## 产品侧修复（已采用方案 A，与 WS 对齐）
+
+此前 `catcher_http_client_destroy` / `catcher_sse_destroy` 仅 `REGISTRY.remove`，**在途请求/SSE 转发仍会在 destroy 后回调 `user_data`** —— 若宿主在 destroy 后释放 `user_data`，即产生与测试相同的 UAF。WS 在 [#15] 已通过 `cancelled_ws_ids` 标记 + 回调前检查解决；本次把同一机制对齐到 HTTP 与 SSE：
+
+- **HTTP**（`http_ffi.rs`）：新增 `cancelled_http_ids` 集合；`destroy` 标记取消 + `cancel_all()` 取消在途请求 + `REGISTRY.remove`；所有异步回调点改用 `invoke_http_callback_if_active(id, …)`，destroy 后不再触发。
+- **SSE**（`sse_ffi.rs`）：新增 `cancelled_sse_ids`；`destroy` 标记取消 + `close()` + remove；后台转发循环每轮检查取消并在回调点用 `invoke_sse_callback_if_active`，destroy 后停止转发。
+- id 由 `HandleRegistry` 单调分配、不复用（`handle_registry.rs:43` `fetch_add`），故"已取消集合只增不清"安全。
+- 仍存在与 WS 相同的极小 TOCTOU 窗口（检查通过后、回调前的瞬间被 destroy）；测试侧的 `Box::leak` 提供兜底，二者叠加后既无测试 UAF，又使 destroy 后回调的窗口收敛到与 WS 一致。
+
+**遗留**：一次性 `catcher_sse_stream`（无句柄、不可取消）的回调会持续到流结束，宿主须在此期间保持 `user_data` 有效 —— 这是该 API 的固有契约，非回归。
+
+## 影响范围小结
+
+| 维度 | 评估 |
+|------|------|
+| 是否大改 | 否（测试侧：3 个 helper 改为 leak） |
+| 是否产品 bug | 测试侧否；产品侧为待评估的契约不对称 |
+| 价值 | 高 —— 消除 CI 整套并行运行的 SIGSEGV，配合 #033 恢复 CI 真实可信 |
+
+## 验证
+
+- `cargo test -p catcher-ffi --test http_test` 并行连跑 5 次：19 passed，无 SIGSEGV。
+- `cargo test -p catcher-ffi --no-fail-fast`：codec(4) + http(19) + quality(5) + sse(3) 全过。
+- `cargo clippy -p catcher-ffi --tests` clean。
+
+## 关联
+
+- [033-quality-test-flake-and-ci-fail-fast.md](./033-quality-test-flake-and-ci-fail-fast.md) — fail-fast 长期掩盖了本 SIGSEGV
+- [002-ffi-callback-cstring-leak-risk.md](./002-ffi-callback-cstring-leak-risk.md) — FFI 回调内存历史问题
+- PR #15 WS dispose UAF 修复（`cancelled_ws_ids`）—— HTTP destroy 可参照对齐

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -66,6 +66,32 @@
 | M-02 | 代理 / VPN / 本地网络兼容范围 | 🔴 P0 | 已调研，待补验证项 | [027-proxy-vpn-network-compatibility-research.md](./027-proxy-vpn-network-compatibility-research.md) |
 
 
+## PR #13~#15 架构 Review 发现（2026-06-13）
+
+> 来源：对 PR #13（`networkChanged()`）、#14（显式代理）、#15（代理 DNS 行为）的严格架构 review。主线功能在 master 上工作正常且有测试兜底；以下为残留的小 bug 与隐性脆弱点。
+
+| # | Issue | 严重 | 状态 | 修复方案 | 文件 |
+|---|-------|:---:|:----:|:------:|------|
+| 28 | `tlsSniOverride` 在 Rust 路径静默失效，与 TS 路径行为不一致 | 🟡 Med | ✅ Fixed | 原生路径显式报错 | [028-tls-sni-override-noop-rust-path.md](./028-tls-sni-override-noop-rust-path.md) |
+| 29 | `networkPathId` 死字段，从未被读取 | 🟢 Low | ✅ Fixed | 移除字段（Rust + 全绑定） | [029-network-path-id-dead-field.md](./029-network-path-id-dead-field.md) |
+| 30 | `networkChanged()` 不恢复在途请求，注释言过其实 | 🟡 Med | ✅ Fixed | 修注释 + 文档化 `+cancelAll()` | [030-network-changed-inflight-requests.md](./030-network-changed-inflight-requests.md) |
+| 31 | 代理远端 DNS 正确性依赖 reqwest 未文档化行为，仅测试兜底 | 🟢 Low-Med | ✅ Fixed | 代码注释 + CI/arch 文档加固 | [031-proxy-dns-relies-on-reqwest-internal-behavior.md](./031-proxy-dns-relies-on-reqwest-internal-behavior.md) |
+| 33 | `q05_subscribe_multiple` 时序 flake + CI 缺 `--no-fail-fast` 掩盖整套件 | 🟡 Med | ✅ Fixed | 改按生命周期断言 + CI 加 `--no-fail-fast` | [033-quality-test-flake-and-ci-fail-fast.md](./033-quality-test-flake-and-ci-fail-fast.md) |
+| 34 | FFI 回调测试 UAF（整套并行 SIGSEGV）+ HTTP/SSE destroy 不抑制在途回调 | 🟡 Med | ✅ Fixed | 测试回调状态 `Box::leak`；HTTP/SSE destroy 加 `cancelled_ids` 与 WS 对齐 | [034-ffi-callback-uaf-test-and-destroy-asymmetry.md](./034-ffi-callback-uaf-test-and-destroy-asymmetry.md) |
+
+**结论**：#28~#31、#33、#34 已全部修复（2026-06-13）。均为局部改动，无连接层重构。验证：`cargo clippy --workspace` 通过、相关单测与 `proxy_dns_behavior_test` 全绿、`quality_test` 5/5 稳定、`http_test` 并行 5/5 无 SIGSEGV、`catcher-ffi` 全套件绿、`pnpm typecheck` 通过；Dart 改动为机械字段移除（本机无 dart 工具链，未跑 analyze）。#34 产品侧已将 HTTP/SSE destroy 与 WS 对齐（destroy 后不再回调 user_data）。
+
+> 排查记录：`connect_stream_uses_dns_host_mapping` 在本机 macOS 沙箱失败，经查 host_mapping 解析正确（连接到达正确 IP:端口），且在 Linux CI 绿色构建（`849187d`）上通过 → 环境特异性，非产品 bug。该测试此前在 CI 未被验证，根因正是 #33 的 fail-fast 截断。
+
+### 由本轮 review 衍生的能力缺口（feature gap，非 bug）
+
+| # | 能力缺口 | 优先级 | 状态 | 方案 | 文件 |
+|---|---------|:------:|:----:|------|------|
+| 32 | WS 尚未实现 `pin_sha256` 证书固定（HTTP 已支持） | 🟡 P1–P2 | 未实现 | A:类型/文档标注（小）· B:抽取共享 pinning（中） | [032-ws-pin-sha256-not-supported.md](./032-ws-pin-sha256-not-supported.md) |
+
+> #32 是 WS 端的能力尚未实现（fail-closed 显式报错，无安全降级），性质与上方 bug 不同，单列。
+
+
 ## 间题之间的关联
 
 ```

--- a/docs/releases/0.3.13.md
+++ b/docs/releases/0.3.13.md
@@ -1,0 +1,107 @@
+# Release Notes — v0.3.13
+
+> 发布日期：2026-06-13 · 对比基线：v0.3.12
+>
+> 本版聚焦**网络韧性**：主动网络切换恢复、移动端代理/VPN 兼容（含远端 DNS），并对齐了一组配置默认行为，修复了一批 review 发现的问题。
+>
+> 📌 **大多数项目无需改代码即可升级**，但 DNS / 代理 / TLS 有几处默认行为变更，升级前请阅读「⚠️ 行为变更」。
+> 简明迁移表见 [`../user-manual/migration.md`](../user-manual/migration.md) 的「版本升级：0.3.x → 0.3.13」一节；逐条变更见 [`../../CHANGELOG.md`](../../CHANGELOG.md)。
+
+---
+
+## 🎯 亮点
+
+- **主动网络切换恢复 `networkChanged()`**：WiFi↔蜂窝、VPN 连接/断开/换节点后，旧连接会静默变成半开连接。宿主从 OS 网络回调中调用 `networkChanged()`，即可立即恢复，不再等被动超时（WS 心跳 10–30s / TCP keepalive 20s / DNS 缓存最长 300s）。
+- **移动端代理 / VPN 兼容**：HTTP 与 WebSocket 共享统一的 `ProxyConfig` / `TlsConfig`，一致支持 HTTP 代理、SOCKS5/SOCKS5h、HTTP CONNECT 与 `no_proxy` 旁路；并确保代理路径下目标域名由代理远端解析（修复 Clash fake-ip / VPN 分流）。
+- **更安全的 FFI 生命周期**：WS/HTTP/SSE 的 `destroy` 现在都会停止在途任务并在销毁后不再回调宿主的 `user_data`。
+
+---
+
+## ✨ 新增 API（增量，无破坏）
+
+| API | 平台 | 说明 |
+|-----|------|------|
+| `networkChanged()` | HTTP / WS（C ABI / napi / UniFFI / Dart） | 主动恢复：清 DNS 缓存、热替换连接池、重置熔断器；WS 立即重连、多端点重新竞速 |
+| `DnsResolver::clear_cache()` | catcher-dns (Rust) | 失效 moka + hickory 缓存 |
+| `WsClientConfig.proxy` / `WsClientConfig.tls` | WS（全平台） | WS 此前**没有**代理/TLS 配置，现新增 |
+| `WsClientConfig.send_timeout_ms` | WS | 默认 `10000`，防半开发送阻塞事件循环 |
+| `DnsConfig.fallback_to_default_nameservers` | HTTP / WS | 新字段，默认 `false`（见行为变更 #2） |
+| SOCKS5 / socks5h 代理实际可用 | HTTP | 0.3.12 未启用 `reqwest/socks` feature，SOCKS 代理此前并不工作 |
+
+---
+
+## ⚠️ 行为变更（vs 0.3.12，升级敏感）
+
+| # | 变更 | 0.3.12 旧行为 | 0.3.13 新行为 | 如何保持旧行为 |
+|---|------|--------------|--------------|----------------|
+| 1 | **DNS 改为按需启用** | 不配 `dns` 也**总是**构建 Catcher resolver（隐式缓存） | 不配 `dns` → 协议库**原生解析** | 显式传入 `dns`（`mode` 默认 `catcher`） |
+| 2 | **不再静默回退公共 DNS** | 读系统 DNS 失败 → 静默用 hickory 默认（公共）nameserver（如 `8.8.8.8`） | 返回 `DnsError` | 设 `dns.fallback_to_default_nameservers = true` |
+| 3 | **`socks5://` 自动按 `socks5h://` 处理** | （SOCKS feature 未开，实际不工作） | 目标域名交给代理远端解析 | 无 —— 有意移除本地解析 socks5 的路径 |
+| 4 | **`tls_sni_override` 原生路径报错** | Rust（catcher-http/ws）路径**静默忽略** | 构建客户端时返回 `InvalidConfig` | 移除该字段；需自定义 SNI 请用纯 TS Node Agent（`servername`） |
+| 5 | **WS 单连接多 IP 握手故障转移移除** | 按 A 记录逐个 IP 重试握手 | 由 reqwest 连接层（happy-eyeballs）处理 | 用多端点竞速 `urls: ['a', 'b']` 获取端点级故障转移 |
+| 6 | **WS FFI `destroy` 语义** | 仅移除句柄（事件循环仍跑、仍回调 → UAF 风险） | 取消事件循环 + 关闭连接，销毁后不再回调 | 无需处理（更安全） |
+| 7 | **HTTP / SSE FFI `destroy` 语义** | 仅移除句柄，在途请求/SSE 仍回调 `user_data`（destroy 后释放 → UAF） | destroy 后取消在途并抑制回调，不再触碰 `user_data` | 无需处理（更安全） |
+
+### 最影响实际接入的两点
+
+1. **#1 DNS opt-in** —— 若此前未显式配 `dns` 却依赖了 catcher 的 DNS 缓存，升级后缓存会消失。这是最常见的「无感知行为变化」，建议接入方确认。
+2. **#3 socks5h** —— 这是修复移动端 Clash/VPN 的核心。若此前用 `socks5://` 且依赖本地解析，行为会变（但该场景本就是坏的）。
+
+---
+
+## ✅ API 兼容性
+
+**对 0.3.12 的公开 API 没有硬性 breaking change。**
+
+- **`network_path_id` / `networkPathId`**：本周期内引入又移除，**从未随正式版发布** → 对 0.3.12 用户净零影响。
+- **共享类型上移**（`ProxyConfig` / `ProxyAuth` / `TlsConfig` / `TlsVersion` → `catcher-core`）：catcher-http/ws 重导出，Rust `catcher_http::types::http::*` 导入路径**保持源码兼容**。
+- **JSON 反序列化未启用 `deny_unknown_fields`**：传入未知/已移除字段会被静默忽略，绑定层 JSON 调用方不会中断。
+
+> 需要关注的不是「编译破坏」，而是上面的「行为变更」。
+
+---
+
+## 📋 升级清单
+
+- [ ] 若依赖隐式 DNS 缓存：为 HTTP/WS 显式传入 `dns` 配置（#1）
+- [ ] 若运行在受限网络且依赖系统 DNS 回退：评估 `fallback_to_default_nameservers`（#2）
+- [ ] 若用 `socks5://` 代理：确认期望的是远端解析（默认）还是本地解析（不再支持）（#3）
+- [ ] 若设置过 `tls_sni_override` 走原生 transport：移除或改用 TS Agent（#4）
+- [ ] 若依赖 WS 单连接多 IP 握手重试：改用多端点竞速 `urls: [...]`（#5）
+- [ ] 复核 FFI 宿主：现在 `destroy` 后不会再回调，可安全释放 `user_data`（#6/#7）
+
+---
+
+## 🐛 修复与改进（issues #28–34）
+
+| # | 摘要 |
+|---|------|
+| 28 | `tls_sni_override` 原生路径由静默失效改为显式报错 |
+| 29 | 移除死字段 `network_path_id`（Rust + TS + Dart） |
+| 30 | 修正 `networkChanged()` 注释，文档化「在途请求需配合 `cancelAll()`」 |
+| 31 | 文档化代理远端 DNS 对 reqwest 内部行为的依赖；CI 必跑 `proxy_dns_behavior_test` |
+| 32 | 记录 WS 尚未实现 `pin_sha256` 证书固定（feature gap，非 bug） |
+| 33 | 修复 `q05_subscribe_multiple` 时序 flake；CI 加 `--no-fail-fast` |
+| 34 | 修复 FFI 回调 use-after-free（测试侧 + HTTP/SSE destroy 与 WS 对齐） |
+
+详见 [`../issues/README.md`](../issues/README.md)。
+
+---
+
+## 🔍 验证
+
+- `cargo clippy --workspace --all-targets -- -D warnings` ✅
+- `cargo check --workspace` ✅（全部 v0.3.13）
+- `catcher-ffi` 全套件 `--no-fail-fast` ✅（codec 4 / http 19 / quality 5 / sse 3）
+- `http_test` 并行 5/5 无 SIGSEGV ✅
+- `proxy_dns_behavior_test`（http + ws）✅
+- `pnpm typecheck` ✅（7 包）
+- Dart：机械字段移除，本机无 dart 工具链未跑 `analyze`
+
+---
+
+## ⚠️ 已知问题 / 限制
+
+- **WS `pin_sha256` 证书固定尚未实现**（issue #32）：在 catcher-ws 设置该字段会返回 `InvalidConfig`（HTTP 已完整支持）。属能力缺口，非 bug。
+- **一次性 `catcher_sse_stream`**（无句柄、不可取消）的回调会持续到流结束，宿主须在此期间保持 `user_data` 有效 —— 该 API 的固有契约。
+- **`connect_stream_uses_dns_host_mapping`** 在 macOS 沙箱本地环境间歇失败（host_mapping 解析正确、Linux CI 通过），属环境特异性，不影响功能。

--- a/docs/user-manual/api/rust-http.md
+++ b/docs/user-manual/api/rust-http.md
@@ -132,12 +132,15 @@ pub struct TlsConfig {
     pub client_key_path: Option<String>,
     pub client_identity_pfx: Option<Vec<u8>>,
     pub client_identity_password: Option<String>,
-    pub tls_sni_override: Option<String>,
+    pub tls_sni_override: Option<String>,     // ⚠️ 原生 transport 不支持：设置会返回 InvalidConfig（仅 TS Node Agent 支持）
     pub min_tls_version: Option<TlsVersion>,  // Tls1_0 | Tls1_1 | Tls1_2 | Tls1_3
     pub max_tls_version: Option<TlsVersion>,
     pub pin_sha256: Option<Vec<String>>,
 }
 ```
+
+> **0.3.13 起**：`tls_sni_override` 在 Rust 原生 transport（catcher-http / catcher-ws）会返回 `InvalidConfig`
+> 错误（reqwest 无法覆写 SNI 主机名），不再静默忽略。如确需自定义 SNI，请使用纯 TS 的 Node Agent 路径。
 
 ### DnsConfig
 

--- a/docs/user-manual/migration.md
+++ b/docs/user-manual/migration.md
@@ -4,6 +4,30 @@
 
 ---
 
+## 版本升级：0.3.x → 0.3.13
+
+0.3.13 引入主动网络切换恢复与移动端代理/VPN 兼容，并对齐了几处默认行为。**大多数项目无需改代码**，但以下默认行为有调整，升级前请逐条确认。完整说明见根目录 [`CHANGELOG.md`](../../CHANGELOG.md)。
+
+| 变更 | 影响 | 如需保持旧行为 |
+|------|------|----------------|
+| **DNS 改为按需启用** | 不配置 `dns` 时使用协议库原生解析（此前总是启用 Catcher DNS 缓存） | 显式传入 `dns`（`mode` 默认 `catcher`），即可恢复缓存 / host mapping / 自定义 nameserver |
+| **不再静默回退公共 DNS** | 读取系统 DNS 配置失败时返回错误，而非静默用 `8.8.8.8` 等公共 nameserver | 设置 `dns.fallback_to_default_nameservers = true`（默认 `false`） |
+| **`socks5://` 按 `socks5h://` 处理** | 代理下目标域名交给代理远端解析（修复 Clash/VPN 分流） | 无 —— 有意移除本地解析 socks5 的路径 |
+| **`tls_sni_override` 原生路径报错** | 在 catcher-http / catcher-ws（Rust/原生）设置该字段会返回 `InvalidConfig` | 移除该字段；若确需自定义 SNI，使用纯 TS 的 Node Agent（`servername`） |
+| **WS 单连接多 IP 握手故障转移移除** | 多 IP 主机不再在握手层逐 IP 重试，改由 reqwest 连接层处理 | 用多端点竞速 `urls: ['a', 'b']` 获取端点级故障转移 |
+| **WS FFI `destroy` 语义** | 销毁现在会取消事件循环并关闭连接（修复 use-after-free） | 无需处理（行为更安全） |
+
+### 新能力（增量，无需迁移）
+
+- **`networkChanged()`**：HTTP / WS / DNS 均新增。从 OS 网络回调中调用即可主动恢复连接。详见 [resilience.md](./resilience.md) 第七节。注意它只影响**之后发起的新请求**；若要连同在途请求一并恢复，调用后再 `cancelAll()`。
+- **统一代理 / TLS 配置**：HTTP 与 WS 共享 `ProxyConfig` / `TlsConfig`，WS 新增 `proxy` / `tls` / `sendTimeoutMs`。
+
+### 已移除字段
+
+- **`networkPathId` / `network_path_id`**：从未随正式版本发布，0.3.13 中移除。网络切换恢复请改用 `networkChanged()`。传入该字段会被静默忽略，不会报错。
+
+---
+
 ## 一、axios → @eric8810/catcher-http
 
 ### 为什么迁移

--- a/docs/user-manual/nodejs.md
+++ b/docs/user-manual/nodejs.md
@@ -205,10 +205,14 @@ contextBridge.exposeInMainWorld('api', {
 
 ## 四、DNS 缓存
 
-配置 `dns` 后默认接入 Catcher DNS，启用 DNS 缓存、旧缓存兜底、
+> **0.3.13 起，DNS 按需启用（opt-in）**：**不传 `dns` 配置时使用协议库原生解析**（不再隐式启用 Catcher DNS）。
+> 一旦传入 `dns` 配置，`mode` 默认即 `catcher`。若想在传了 `dns` 的同时仍走原生解析，显式设置 `dns.mode = 'native'`。
+
+传入 `dns` 配置后默认接入 Catcher DNS，启用 DNS 缓存、旧缓存兜底、
 自定义 nameserver 和 host mapping。代理场景下，目标域名交给代理解析，
-Catcher DNS 不会提前把目标域名改成 IP。只有显式配置
-`dns.mode = 'native'` 时，才使用底层协议库原生解析。
+Catcher DNS 不会提前把目标域名改成 IP。
+读取系统 DNS 配置失败时默认返回错误而非静默回退到公共 nameserver；
+如需回退，设置 `dns.fallbackToDefaultNameservers = true`。
 
 | 配置 | 说明 | 默认值 |
 |------|------|--------|

--- a/docs/user-manual/resilience.md
+++ b/docs/user-manual/resilience.md
@@ -723,9 +723,21 @@ Android `ConnectivityManager`、Flutter `connectivity_plus`、浏览器
 **HTTP 客户端**（`HttpTransport::network_changed()` / `client.networkChanged()`）：
 
 1. 清空 DNS 缓存
-2. 重建连接池 — 丢弃所有可能半开的 keep-alive 连接
+2. 重建连接池 — 丢弃所有可能半开的 keep-alive 连接，**后续新请求**走全新连接
 3. 重置熔断器 — 切换期间的失败不应让新网络背锅
-4. 飞行中的请求不受影响（其重试会自动建立新连接）
+
+> ⚠️ **在途请求不会被自动恢复**：连接池热替换只影响调用之后发起的新请求。
+> 调用 `networkChanged()` 时**正在进行中**的请求（尤其流式下载、慢响应）仍持有
+> 旧连接，会继续阻塞在已半开的 socket 上，直到其自身 `responseTimeoutMs` 超时
+> （除非配置了可重试的 `retry`）。若希望网络切换时连同在途请求一并恢复，请在
+> `networkChanged()` 之后调用 `cancelAll()` —— 在途请求会立即失败，由上层决定是否重发：
+>
+> ```typescript
+> onNetworkChange(() => {
+>   httpClient.networkChanged()
+>   httpClient.cancelAll()   // 主动中断在途请求，使其立即失败而非干等超时
+> })
+> ```
 
 ### 7.3 各平台用法
 

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-core"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-dns"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "catcher-core",
  "hickory-proto",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-ffi"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "catcher-core",
  "catcher-http",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-http"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "async-trait",
  "backon",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-napi-http"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "base64",
  "bytes",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-napi-ws"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "catcher-ws",
  "napi",
@@ -424,14 +424,14 @@ dependencies = [
 
 [[package]]
 name = "catcher-test-support"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "catcher-uniffi"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "catcher-core",
  "catcher-http",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-ws"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "backon",
  "base64",

--- a/packages/catcher-core-ts/package.json
+++ b/packages/catcher-core-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-core",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Catcher shared type definitions — zero runtime dependencies",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-core-ts/src/types.ts
+++ b/packages/catcher-core-ts/src/types.ts
@@ -150,8 +150,6 @@ export interface HttpClientConfig {
   xsrfCookieName?: string
   /** XSRF/CSRF header name. Default: "X-XSRF-TOKEN" */
   xsrfHeaderName?: string
-  /** Network path version. Recreate clients after VPN/proxy/DNS changes with a new value. */
-  networkPathId?: string
 }
 
 // === Per-request Options ===
@@ -293,8 +291,6 @@ export interface ResilientWSOptions {
   cookie?: string
   // --- G4: Proxy for WS connections ---
   proxy?: boolean | string | ProxyConfig
-  /** Network path version. Recreate clients after VPN/proxy/DNS changes with a new value. */
-  networkPathId?: string
 }
 
 export interface ResilientWS extends EventTarget {

--- a/packages/catcher-core/Cargo.toml
+++ b/packages/catcher-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-core"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "Shared core types and errors for catcher — zero I/O dependencies"
 license = "MIT"

--- a/packages/catcher-core/src/types/network.rs
+++ b/packages/catcher-core/src/types/network.rs
@@ -45,7 +45,11 @@ pub struct TlsConfig {
         skip_serializing_if = "Option::is_none"
     )]
     pub client_identity_password: Option<String>,
-    /// TLS SNI 覆写。
+    /// TLS SNI 主机名覆写。
+    ///
+    /// 仅纯 TS 路径（catcher-http-ts 的 Node Agent，通过 `servername`）支持。
+    /// 原生 transport（catcher-http / catcher-ws）基于 reqwest，无法覆写 SNI 主机名，
+    /// 设置此字段会在构建客户端时返回 `InvalidConfig` 错误（而非静默忽略）。详见 issue #028。
     #[serde(alias = "tlsSniOverride", skip_serializing_if = "Option::is_none")]
     pub tls_sni_override: Option<String>,
     /// 最低 TLS 版本。

--- a/packages/catcher-dns/Cargo.toml
+++ b/packages/catcher-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-dns"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "Shared DNS resolver for catcher — cache, host mapping, and stale fallback"
 license = "MIT"
@@ -12,7 +12,7 @@ hickory-dns = ["dep:hickory-resolver", "dep:hickory-proto", "dep:moka"]
 reqwest-resolver = ["dep:reqwest"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.12" }
+catcher-core = { path = "../catcher-core", version = "0.3.13" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["net", "rt", "time", "macros"] }
 parking_lot = "0.12"

--- a/packages/catcher-ffi/Cargo.toml
+++ b/packages/catcher-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-ffi"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "Unified C ABI library for catcher — links HTTP + WS + codec into a single .so/.dylib"
 license = "MIT"
@@ -11,15 +11,15 @@ crate-type = ["cdylib", "lib"]
 name = "catcher_ffi"
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.12" }
-catcher-http = { path = "../catcher-http", version = "0.3.12" }
-catcher-ws = { path = "../catcher-ws", version = "0.3.12" }
+catcher-core = { path = "../catcher-core", version = "0.3.13" }
+catcher-http = { path = "../catcher-http", version = "0.3.13" }
+catcher-ws = { path = "../catcher-ws", version = "0.3.13" }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.12" }
-catcher-http = { path = "../catcher-http", version = "0.3.12" }
-catcher-ws = { path = "../catcher-ws", version = "0.3.12" }
+catcher-core = { path = "../catcher-core", version = "0.3.13" }
+catcher-http = { path = "../catcher-http", version = "0.3.13" }
+catcher-ws = { path = "../catcher-ws", version = "0.3.13" }
 wiremock = "0.6"
 tokio-test = "0.4"

--- a/packages/catcher-ffi/tests/http_test.rs
+++ b/packages/catcher-ffi/tests/http_test.rs
@@ -7,7 +7,7 @@
 //!   cargo test -p catcher-ffi --test http_test
 
 use std::ffi::{c_char, c_void, CStr, CString};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use catcher_core::ffi_types::FfiString;
 use catcher_http::ffi::http_ffi as http;
@@ -298,10 +298,15 @@ extern "C" fn capture_to_result(
     *result.lock().unwrap() = Some(json);
 }
 
-fn make_result_cell() -> (Arc<Mutex<Option<String>>>, *mut c_void) {
-    let cell = Arc::new(Mutex::new(None::<String>));
-    let ptr = Arc::as_ptr(&cell) as *mut c_void;
-    (cell, ptr)
+// 故意泄漏 user_data 指向的内存：回调可能在测试函数返回后才由后台全局 runtime 触发
+// （in-flight / 被取消的请求，且 destroy 不会同步停止回调）。若用 Arc 并在测试结束时
+// drop，user_data 指针会悬空 → use-after-free（多测试并行时表现为 SIGSEGV）。测试进程
+// 生命周期内泄漏一个小 Mutex 可忽略，且与「宿主须在回调存活期间保持 user_data 有效」的
+// FFI 契约一致。详见 docs/issues/034。
+fn make_result_cell() -> (&'static Mutex<Option<String>>, *mut c_void) {
+    let leaked: &'static Mutex<Option<String>> = Box::leak(Box::new(Mutex::new(None::<String>)));
+    let ptr = leaked as *const Mutex<Option<String>> as *mut c_void;
+    (leaked, ptr)
 }
 
 #[tokio::test]
@@ -631,11 +636,13 @@ extern "C" fn capture_stream_events(
     events.lock().unwrap().push((et, data));
 }
 
+// 同 make_result_cell：泄漏以保证后台 runtime 的延迟回调始终写入有效内存。
 #[allow(clippy::type_complexity)]
-fn make_events_cell() -> (Arc<Mutex<Vec<(String, String)>>>, *mut c_void) {
-    let cell = Arc::new(Mutex::new(Vec::<(String, String)>::new()));
-    let ptr = Arc::as_ptr(&cell) as *mut c_void;
-    (cell, ptr)
+fn make_events_cell() -> (&'static Mutex<Vec<(String, String)>>, *mut c_void) {
+    let leaked: &'static Mutex<Vec<(String, String)>> =
+        Box::leak(Box::new(Mutex::new(Vec::<(String, String)>::new())));
+    let ptr = leaked as *const Mutex<Vec<(String, String)>> as *mut c_void;
+    (leaked, ptr)
 }
 
 #[tokio::test]

--- a/packages/catcher-ffi/tests/quality_test.rs
+++ b/packages/catcher-ffi/tests/quality_test.rs
@@ -4,7 +4,7 @@
 //!   cargo test -p catcher-ffi --test quality_test
 
 use std::ffi::{c_char, c_void, CString};
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use catcher_core::ffi_types::FfiString;
 use catcher_http::ffi::quality_ffi as quality;
@@ -15,13 +15,16 @@ struct CallbackState {
     last_event: Option<String>,
 }
 
-fn make_callback_state() -> (Arc<Mutex<CallbackState>>, *mut c_void) {
-    let state = Arc::new(Mutex::new(CallbackState {
+// 故意泄漏 user_data 指向的内存：质量订阅的回调由后台 runtime 周期性触发，可能在测试
+// 退订/返回后仍发生一次（abort 对同步回调存在竞态窗口）。若用 Arc 并在测试结束时 drop，
+// user_data 会悬空 → UAF。泄漏一个小状态在测试进程内可忽略。详见 docs/issues/034。
+fn make_callback_state() -> (&'static Mutex<CallbackState>, *mut c_void) {
+    let leaked: &'static Mutex<CallbackState> = Box::leak(Box::new(Mutex::new(CallbackState {
         count: 0,
         last_event: None,
-    }));
-    let ptr = Arc::as_ptr(&state) as *mut c_void;
-    (state, ptr)
+    })));
+    let ptr = leaked as *const Mutex<CallbackState> as *mut c_void;
+    (leaked, ptr)
 }
 
 extern "C" fn capture_quality_callback(
@@ -168,15 +171,27 @@ async fn q05_subscribe_multiple() {
 
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
+    // 退订 sub1，记录此刻两者计数。
     unsafe { quality::catcher_quality_unsubscribe(sub1) };
-    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    let count1_at_unsub = state1.lock().unwrap().count;
+    let count2_at_unsub = state2.lock().unwrap().count;
 
-    let count1 = state1.lock().unwrap().count;
-    let count2 = state2.lock().unwrap().count;
-    // sub2 should still be receiving callbacks (or at least not panicked)
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let count1_final = state1.lock().unwrap().count;
+    let count2_final = state2.lock().unwrap().count;
+
+    // 独立性断言 —— 按每个订阅各自的生命周期判断，不比较两个 prober 的相对速度
+    // （回调由真实网络探测触发，相对快慢非确定，旧的 `count2 >= count1` 因此 flaky）。
+    // 1) sub1 退订后不再新增回调（与 q03 相同的稳定语义）。
+    assert_eq!(
+        count1_final, count1_at_unsub,
+        "sub1 退订后不应再收到回调"
+    );
+    // 2) sub2 不受 sub1 退订影响，计数单调不减（独立工作）。
     assert!(
-        count2 >= count1,
-        "sub2 should have at least as many callbacks as sub1"
+        count2_final >= count2_at_unsub,
+        "sub2 不应受 sub1 退订影响"
     );
 
     unsafe { quality::catcher_quality_unsubscribe(sub2) };

--- a/packages/catcher-http-ts/package.json
+++ b/packages/catcher-http-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-http",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Catcher HTTP client — resilient transport with retry, circuit breaker, priority scheduling",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-http/Cargo.toml
+++ b/packages/catcher-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-http"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "HTTP client for catcher — resilient transport with retry, circuit breaker, priority scheduling"
 license = "MIT"
@@ -14,8 +14,8 @@ hickory-dns = ["catcher-dns/hickory-dns", "catcher-dns/reqwest-resolver"]
 napi = ["dep:napi", "dep:napi-derive"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.12" }
-catcher-dns = { path = "../catcher-dns", version = "0.3.12", default-features = false }
+catcher-core = { path = "../catcher-core", version = "0.3.13" }
+catcher-dns = { path = "../catcher-dns", version = "0.3.13", default-features = false }
 
 # ── 异步运行时 ──
 tokio = { version = "1", features = ["sync", "time", "net", "io-util", "macros"] }
@@ -27,6 +27,8 @@ tokio-stream = "0.1"
 bytes = "1"
 
 # ── HTTP 传输 ──
+# ⚠️ 升级 reqwest 时务必重跑 tests/proxy_dns_behavior_test.rs：代理路径下「目标域名交给
+# 代理远端解析、不被本地 resolver 解析」依赖 reqwest 内部行为，非明文 API 承诺（issue #031）。
 reqwest = { version = "0.13", default-features = false, features = [
     "http2", "gzip", "brotli", "deflate", "stream", "charset", "query", "form", "socks"
 ] }

--- a/packages/catcher-http/src/ffi/http_ffi.rs
+++ b/packages/catcher-http/src/ffi/http_ffi.rs
@@ -57,6 +57,36 @@ fn runtime() -> &'static tokio::runtime::Runtime {
     })
 }
 
+/// 已销毁句柄的 id 集合。请求在全局 runtime 上异步执行，destroy 后其回调仍可能触发；
+/// 标记取消后，回调前检查此集合即可避免在 destroy 后再回调宿主的 `user_data`
+/// （宿主可能已释放 → use-after-free）。与 WS 的 `cancelled_ws_ids` 对齐。详见 issue #034。
+/// id 由 HandleRegistry 单调分配、不复用，故集合只增不清是安全的。
+fn cancelled_http_ids() -> &'static std::sync::RwLock<std::collections::HashSet<usize>> {
+    static CANCELLED: std::sync::OnceLock<std::sync::RwLock<std::collections::HashSet<usize>>> =
+        std::sync::OnceLock::new();
+    CANCELLED.get_or_init(|| std::sync::RwLock::new(std::collections::HashSet::new()))
+}
+
+fn mark_http_cancelled(id: usize) {
+    let lock = cancelled_http_ids();
+    match lock.write() {
+        Ok(mut ids) => {
+            ids.insert(id);
+        }
+        Err(poisoned) => {
+            poisoned.into_inner().insert(id);
+        }
+    }
+}
+
+fn is_http_cancelled(id: usize) -> bool {
+    let lock = cancelled_http_ids();
+    match lock.read() {
+        Ok(ids) => ids.contains(&id),
+        Err(poisoned) => poisoned.into_inner().contains(&id),
+    }
+}
+
 fn ffi_string_to_string(s: FfiString, default: &str) -> String {
     s.to_string_lossy(default)
 }
@@ -101,6 +131,21 @@ fn invoke_http_callback(callback: EventCallback, event_name: &str, json: String,
     );
 }
 
+/// 仅当句柄未被 destroy 时才回调。用于异步任务在请求完成时的回调点，避免 destroy
+/// 后仍触发宿主 `user_data`（issue #034）。
+fn invoke_http_callback_if_active(
+    id: usize,
+    callback: EventCallback,
+    event_name: &str,
+    json: String,
+    user_data: usize,
+) {
+    if is_http_cancelled(id) {
+        return;
+    }
+    invoke_http_callback(callback, event_name, json, user_data);
+}
+
 // ── Lifecycle ──
 
 /// 创建 HTTP 客户端。返回的句柄是注册表 id 直接编码为指针值（id ≥ 1，
@@ -130,6 +175,13 @@ pub unsafe extern "C" fn catcher_http_client_destroy(handle: *mut c_void) {
         return;
     }
     let id = handle as usize;
+    // 标记取消，阻止 destroy 后在途请求的回调再触发宿主 `user_data`（与 WS 对齐，
+    // 避免宿主在 destroy 后释放 user_data 造成 use-after-free，issue #034）。
+    mark_http_cancelled(id);
+    // 取消在途请求，使其尽快终止（其回调会被上面的标记抑制）。
+    if let Some(t) = REGISTRY.get(id) {
+        t.cancel_all();
+    }
     REGISTRY.remove(id);
 }
 
@@ -170,7 +222,7 @@ pub unsafe extern "C" fn catcher_http_get(
             };
             let result = t.execute(request).await;
             let json = http_result_to_json(result);
-            invoke_http_callback(callback, "http_result", json, ud);
+            invoke_http_callback_if_active(id, callback, "http_result", json, ud);
         });
     }
 }
@@ -215,7 +267,7 @@ pub unsafe extern "C" fn catcher_http_post(
             };
             let result = t.execute(request).await;
             let json = http_result_to_json(result);
-            invoke_http_callback(callback, "http_result", json, ud);
+            invoke_http_callback_if_active(id, callback, "http_result", json, ud);
         });
     }
 }
@@ -289,7 +341,7 @@ pub unsafe extern "C" fn catcher_http_execute(
             };
             let result = t.execute(request).await;
             let json = http_result_to_json(result);
-            invoke_http_callback(callback, "http_result", json, ud);
+            invoke_http_callback_if_active(id, callback, "http_result", json, ud);
         });
     }
 }
@@ -407,7 +459,7 @@ pub unsafe extern "C" fn catcher_http_execute_with_id(
                     }
                 }
             };
-            invoke_http_callback(callback, "http_result", json, ud);
+            invoke_http_callback_if_active(id, callback, "http_result", json, ud);
         });
         request_id
     } else {
@@ -604,7 +656,7 @@ pub unsafe extern "C" fn catcher_http_execute_stream(
                         ("stream_error", serde_json::json!({"error":msg,"request_id":request_id}).to_string())
                     }
                 };
-                invoke_http_callback(callback, et, ed, ud);
+                invoke_http_callback_if_active(id, callback, et, ed, ud);
             }).await;
         });
         request_id
@@ -735,7 +787,7 @@ pub unsafe extern "C" fn catcher_http_multipart(
             };
             let result = t.execute(request).await;
             let json = http_result_to_json(result);
-            invoke_http_callback(callback, "http_result", json, ud);
+            invoke_http_callback_if_active(id_val, callback, "http_result", json, ud);
         });
     }
 }

--- a/packages/catcher-http/src/ffi/sse_ffi.rs
+++ b/packages/catcher-http/src/ffi/sse_ffi.rs
@@ -64,6 +64,49 @@ fn invoke_sse_callback(callback: EventCallback, json: String, user_data: usize) 
     );
 }
 
+/// 已销毁的 SSE 句柄 id 集合。后台转发循环在 destroy 后仍可能回调，标记取消后回调前
+/// 检查可避免在 destroy 后触发宿主 `user_data`（use-after-free）。与 WS/HTTP 对齐。
+/// 详见 issue #034。id 由 HandleRegistry 单调分配、不复用，集合只增是安全的。
+fn cancelled_sse_ids() -> &'static std::sync::RwLock<std::collections::HashSet<usize>> {
+    static CANCELLED: std::sync::OnceLock<std::sync::RwLock<std::collections::HashSet<usize>>> =
+        std::sync::OnceLock::new();
+    CANCELLED.get_or_init(|| std::sync::RwLock::new(std::collections::HashSet::new()))
+}
+
+fn mark_sse_cancelled(id: usize) {
+    let lock = cancelled_sse_ids();
+    match lock.write() {
+        Ok(mut ids) => {
+            ids.insert(id);
+        }
+        Err(poisoned) => {
+            poisoned.into_inner().insert(id);
+        }
+    }
+}
+
+fn is_sse_cancelled(id: usize) -> bool {
+    let lock = cancelled_sse_ids();
+    match lock.read() {
+        Ok(ids) => ids.contains(&id),
+        Err(poisoned) => poisoned.into_inner().contains(&id),
+    }
+}
+
+/// 仅当句柄未被 destroy 时回调；返回 false 表示已取消（调用方应停止转发循环）。
+fn invoke_sse_callback_if_active(
+    id: usize,
+    callback: EventCallback,
+    json: String,
+    user_data: usize,
+) -> bool {
+    if is_sse_cancelled(id) {
+        return false;
+    }
+    invoke_sse_callback(callback, json, user_data);
+    true
+}
+
 fn parse_headers_json(headers_json: *const c_char) -> HashMap<String, String> {
     if headers_json.is_null() {
         return HashMap::new();
@@ -204,21 +247,35 @@ pub unsafe extern "C" fn catcher_sse_connect(
                     // Spawn background task to forward SSE lines to callback
                     sse_runtime().spawn(async move {
                         loop {
+                            // destroy 后停止转发，避免回调已释放的 user_data（issue #034）。
+                            if is_sse_cancelled(id) {
+                                break;
+                            }
                             let mut c = client_arc.lock().await;
                             let line_result = c.next_line().await;
                             drop(c); // release lock before invoking callback
                             match line_result {
                                 Some(Ok(line)) => {
                                     let json = build_sse_event_json("data", &line);
-                                    invoke_sse_callback(callback_ptr, json, ud);
+                                    if !invoke_sse_callback_if_active(id, callback_ptr, json, ud) {
+                                        break;
+                                    }
                                 }
                                 Some(Err(e)) => {
                                     let err_json = build_sse_event_json("error", &e.to_string());
-                                    invoke_sse_callback(callback_ptr, err_json, ud);
+                                    if !invoke_sse_callback_if_active(id, callback_ptr, err_json, ud)
+                                    {
+                                        break;
+                                    }
                                 }
                                 None => {
                                     let done_json = build_sse_event_json("close", "");
-                                    invoke_sse_callback(callback_ptr, done_json, ud);
+                                    let _ = invoke_sse_callback_if_active(
+                                        id,
+                                        callback_ptr,
+                                        done_json,
+                                        ud,
+                                    );
                                     break;
                                 }
                             }
@@ -292,5 +349,10 @@ pub unsafe extern "C" fn catcher_sse_destroy(sse_handle: *mut c_void) {
         return;
     }
     let id = sse_handle as usize;
+    // 标记取消并关闭，阻止后台转发循环在 destroy 后再回调宿主 user_data（issue #034）。
+    mark_sse_cancelled(id);
+    if let Some(client) = SSE_REGISTRY.get(id) {
+        client.blocking_lock().close();
+    }
     SSE_REGISTRY.remove(id);
 }

--- a/packages/catcher-http/src/transport/http_client.rs
+++ b/packages/catcher-http/src/transport/http_client.rs
@@ -134,10 +134,14 @@ impl HttpTransport {
     /// TCP keepalive 探针（默认 20s）或请求失败才会清理。调用此方法立即：
     ///
     /// 1. 清空 DNS 缓存 — 新网络下解析结果可能不同（VPN 场景尤其明显）
-    /// 2. 重建底层客户端 — 丢弃整个旧连接池，后续请求走全新 TCP 连接
+    /// 2. 重建底层客户端 — 丢弃整个旧连接池，**后续新请求**走全新 TCP 连接
     /// 3. 重置熔断器 — 切换期间的失败属于旧网络，不应惩罚新网络
     ///
-    /// 飞行中的请求不受影响：其内部重试会自动建立新连接。
+    /// 注意：连接池热替换只影响**调用之后发起的新请求**。调用时正在进行中的
+    /// 请求（尤其 `execute_stream` 流式下载、慢响应）仍持有旧连接，会继续阻塞
+    /// 在已半开的 socket 上，直到其自身 `response_timeout_ms` 超时——除非配置了
+    /// 可重试的 `retry` 且失败可重试。若希望网络切换时连同在途请求一并恢复，请在
+    /// `network_changed()` 之后调用 `cancel_all()`（在途请求会失败，由上层决定重发）。
     pub fn network_changed(&self) -> Result<(), CatcherError> {
         // 清缓存 + 重建解析器（重读系统 DNS 配置、重连 nameserver）。
         // 重建失败时旧解析器仍可用且缓存已清空，继续重建连接池
@@ -196,6 +200,16 @@ fn build_middleware_client(
     reqwest_builder = build_tls_config(reqwest_builder, &config.tls)?;
 
     // G7: DNS resolution — only use Catcher resolver when explicitly configured.
+    //
+    // 正确性依赖 reqwest 的内部行为（issue #031）：当请求走代理时，reqwest **不会**
+    // 调用这里注入的自定义 dns_resolver —— 目标域名交给代理远端解析（socks5h / HTTP
+    // CONNECT 把 authority 原样转发）。因此即使开启 Catcher DNS，代理路径上的目标域名
+    // 也不会被本地解析成 IP（否则会破坏 Clash 域名分流）。resolver 只作用于直连 /
+    // no_proxy 命中的 host，故必须始终注入、不能"配了代理就不注入"。
+    //
+    // 这一行为未见于 reqwest 的稳定 API 承诺。唯一回归护栏是 proxy_dns_behavior_test
+    // （协议级断言代理收到的是域名而非 IP），随 `cargo test --workspace`（默认含
+    // hickory-dns）在 CI 运行。**升级 reqwest 必须重跑该测试。**
     #[cfg(feature = "hickory-dns")]
     {
         if let Some(resolver) = dns_resolver {

--- a/packages/catcher-http/src/transport/tls.rs
+++ b/packages/catcher-http/src/transport/tls.rs
@@ -11,6 +11,18 @@ pub fn build_tls_config(
     mut builder: ClientBuilder,
     config: &TlsConfig,
 ) -> Result<ClientBuilder, CatcherError> {
+    // SNI 主机名覆写：reqwest 0.13 的 `tls_sni()` 只接受布尔开关（是否发送 SNI），
+    // 无法覆写 SNI 主机名（ServerName 由 URL host 在连接时决定）。与其静默忽略让调用方
+    // 误以为生效，不如显式报错。纯 TS 路径（catcher-http-ts 的 Node Agent）通过
+    // `servername` 支持该能力，原生 transport 暂不对齐。详见 docs/issues/028。
+    if config.tls_sni_override.is_some() {
+        return Err(CatcherError::InvalidConfig(
+            "tls.tls_sni_override is not supported on the native transport: reqwest cannot \
+             override the SNI hostname. Omit the field, or use the TS agent path which supports it."
+                .into(),
+        ));
+    }
+
     // If pin_sha256 is set, build a full rustls::ClientConfig with pinning verifier
     #[cfg(feature = "rustls-tls")]
     if config
@@ -98,12 +110,6 @@ pub fn build_tls_config(
         });
     }
 
-    // TLS SNI override
-    // NOTE: reqwest 0.12 tls_sni() takes a bool (enable/disable SNI), not a hostname.
-    if let Some(ref _sni) = config.tls_sni_override {
-        builder = builder.tls_sni(true);
-    }
-
     Ok(builder)
 }
 
@@ -164,11 +170,7 @@ fn build_tls_with_pinning(
         .with_custom_certificate_verifier(pinning_verifier)
         .with_no_client_auth();
 
-    // SNI
-    let mut tls_config = tls_config;
-    if config.tls_sni_override.is_some() {
-        tls_config.enable_sni = true;
-    }
+    // 注：tls_sni_override 已在 build_tls_config 入口统一拒绝，此处无需处理。
 
     // Inject into reqwest
     let builder = builder.use_preconfigured_tls(tls_config);
@@ -221,14 +223,15 @@ mod tests {
     }
 
     #[test]
-    fn tls5_sni_override() {
+    fn tls5_sni_override_is_rejected() {
+        // reqwest 无法覆写 SNI 主机名，原生 transport 显式拒绝而非静默忽略（issue #028）。
         let config = TlsConfig {
             tls_sni_override: Some("custom-sni.example.com".to_string()),
             ..Default::default()
         };
         let builder = reqwest::Client::builder();
         let result = build_tls_config(builder, &config);
-        assert!(result.is_ok());
+        assert!(matches!(result, Err(CatcherError::InvalidConfig(_))));
     }
 
     #[test]

--- a/packages/catcher-http/src/types/http.rs
+++ b/packages/catcher-http/src/types/http.rs
@@ -201,10 +201,6 @@ pub struct HttpClientConfig {
     /// 启用 msgpack 编解码 — body 自动 JSON↔msgpack 转码
     #[serde(default)]
     pub msgpack: bool,
-
-    /// 网络路径版本。外部平台在 VPN / 代理 / DNS 变化时应传入新的值并重建 client。
-    #[serde(alias = "networkPathId", skip_serializing_if = "Option::is_none")]
-    pub network_path_id: Option<String>,
 }
 
 fn default_connect_timeout() -> u64 {
@@ -236,7 +232,6 @@ impl Default for HttpClientConfig {
             auth: None,
             bearer_token: None,
             msgpack: false,
-            network_path_id: None,
         }
     }
 }

--- a/packages/catcher-napi-http/Cargo.toml
+++ b/packages/catcher-napi-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-napi-http"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "catcher HTTP napi-rs Node.js native bindings"
 license = "MIT"
@@ -9,8 +9,8 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.12" }
-catcher-http = { path = "../catcher-http", version = "0.3.12" }
+catcher-core = { path = "../catcher-core", version = "0.3.13" }
+catcher-http = { path = "../catcher-http", version = "0.3.13" }
 napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 serde = { version = "1", features = ["derive"] }

--- a/packages/catcher-napi-http/package.json
+++ b/packages/catcher-napi-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-napi-http",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "catcher HTTP native addon for Node.js via napi-rs",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/packages/catcher-napi-http/ts/types.ts
+++ b/packages/catcher-napi-http/ts/types.ts
@@ -173,8 +173,6 @@ export interface HttpClientConfig {
   bearer_token?: string
   /** 启用 msgpack 编解码 — body 自动 JSON↔msgpack 转码. 默认 false */
   msgpack?: boolean
-  /** 网络路径版本。VPN / 代理 / DNS 变化后传入新值并重建 client。 */
-  network_path_id?: string
 }
 
 /** SSE 客户端配置 — 对应 Rust SseClientConfig */

--- a/packages/catcher-napi-ws/Cargo.toml
+++ b/packages/catcher-napi-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-napi-ws"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "catcher WebSocket napi-rs Node.js native bindings"
 license = "MIT"
@@ -9,7 +9,7 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-catcher-ws = { path = "../catcher-ws", version = "0.3.12", features = ["rustls-tls"] }
+catcher-ws = { path = "../catcher-ws", version = "0.3.13", features = ["rustls-tls"] }
 napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 serde_json = "1"

--- a/packages/catcher-napi-ws/package.json
+++ b/packages/catcher-napi-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-napi-ws",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "catcher WebSocket native addon for Node.js via napi-rs",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/packages/catcher-napi-ws/ts/types.ts
+++ b/packages/catcher-napi-ws/ts/types.ts
@@ -124,8 +124,6 @@ export interface WsClientConfig {
   dns?: DnsConfig
   /** 启用 msgpack 编解码 — send 自动 JSON→msgpack, receive 自动 msgpack→JSON. 默认 false */
   msgpack?: boolean
-  /** 网络路径版本。VPN / 代理 / DNS 变化后传入新值并重建 client。 */
-  network_path_id?: string
 }
 
 /** WebSocket 事件 — 所有回调参数的联合类型 */

--- a/packages/catcher-test-support/Cargo.toml
+++ b/packages/catcher-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-test-support"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 publish = false
 

--- a/packages/catcher-uniffi/Cargo.toml
+++ b/packages/catcher-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-uniffi"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "UniFFI bindings for catcher — auto-generates Swift + Kotlin from Rust API"
 license = "MIT"
@@ -11,9 +11,9 @@ crate-type = ["cdylib", "staticlib"]
 name = "catcher_uniffi"
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.12" }
-catcher-http = { path = "../catcher-http", version = "0.3.12" }
-catcher-ws = { path = "../catcher-ws", version = "0.3.12" }
+catcher-core = { path = "../catcher-core", version = "0.3.13" }
+catcher-http = { path = "../catcher-http", version = "0.3.13" }
+catcher-ws = { path = "../catcher-ws", version = "0.3.13" }
 uniffi = { version = "0.28", features = ["cli"] }
 serde_json = "1"
 thiserror = "1"

--- a/packages/catcher-web/package.json
+++ b/packages/catcher-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-web",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Catcher HTTP client for browsers — fetch-based with retry, circuit breaker & priority queue",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-ws-ts/package.json
+++ b/packages/catcher-ws-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-ws",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Catcher WebSocket client — resilient reconnect, multi-endpoint racing, msgpack codec",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-ws/Cargo.toml
+++ b/packages/catcher-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-ws"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 description = "WebSocket client for catcher — resilient reconnect, heartbeat, multi-endpoint racing"
 license = "MIT"
@@ -11,8 +11,8 @@ default = ["rustls-tls"]
 rustls-tls = ["yawc/rustls-ring", "reqwest/rustls"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.12" }
-catcher-dns = { path = "../catcher-dns", version = "0.3.12", features = ["reqwest-resolver"] }
+catcher-core = { path = "../catcher-core", version = "0.3.13" }
+catcher-dns = { path = "../catcher-dns", version = "0.3.13", features = ["reqwest-resolver"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "net", "io-util", "macros"] }
 futures-util = "0.3"
 backon = "1"

--- a/packages/catcher-ws/src/transport/ws_client.rs
+++ b/packages/catcher-ws/src/transport/ws_client.rs
@@ -358,8 +358,13 @@ fn build_reqwest_tls_config(
         builder = builder.max_tls_version(map_tls_version(max));
     }
 
+    // SNI 主机名覆写：reqwest 0.13 的 `tls_sni()` 只接受布尔开关，无法覆写 SNI 主机名。
+    // 与其静默忽略，不如显式报错，避免调用方误以为生效。详见 docs/issues/028。
     if config.tls_sni_override.is_some() {
-        builder = builder.tls_sni(true);
+        return Err(CatcherError::InvalidConfig(
+            "ws tls.tls_sni_override is not supported: reqwest cannot override the SNI hostname"
+                .into(),
+        ));
     }
 
     Ok(builder)
@@ -376,6 +381,10 @@ pub(crate) fn build_reqwest_client(
 
     builder = build_reqwest_tls_config(builder, &config.tls)?;
 
+    // 仅在显式 Catcher DNS 模式下注入自定义 resolver。与 HTTP 路径一致，正确性依赖
+    // reqwest 的内部行为（issue #031）：走代理时 reqwest 不调用此 resolver，目标域名
+    // 交给代理远端解析。护栏为 proxy_dns_behavior_test（随 cargo test --workspace 运行）。
+    // **升级 reqwest 必须重跑该测试。**
     if let Some(ref dns_config) = config.dns {
         if dns_config.use_catcher_resolver() {
             let resolver = build_reqwest_resolver(dns_config)?;
@@ -1607,7 +1616,7 @@ mod tests {
     }
 
     #[test]
-    fn config_accepts_proxy_tls_dns_and_network_path() {
+    fn config_accepts_proxy_tls_and_dns() {
         let json = r#"{
             "urls": ["wss://example.com/ws"],
             "proxy": {
@@ -1616,8 +1625,7 @@ mod tests {
                 "no_proxy": ["localhost"]
             },
             "tls": {"reject_unauthorized": false, "min_tls_version": "Tls1_2"},
-            "dns": {"mode": "native"},
-            "network_path_id": "vpn-on"
+            "dns": {"mode": "native"}
         }"#;
 
         let config: WsClientConfig = serde_json::from_str(json).unwrap();
@@ -1628,6 +1636,5 @@ mod tests {
         assert!(!config.tls.reject_unauthorized);
         assert_eq!(config.tls.min_tls_version, Some(TlsVersion::Tls1_2));
         assert!(!config.dns.as_ref().unwrap().use_catcher_resolver());
-        assert_eq!(config.network_path_id.as_deref(), Some("vpn-on"));
     }
 }

--- a/packages/catcher-ws/src/types/ws.rs
+++ b/packages/catcher-ws/src/types/ws.rs
@@ -233,10 +233,6 @@ pub struct WsClientConfig {
     /// DNS 配置
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dns: Option<DnsConfig>,
-
-    /// 网络路径版本。外部平台在 VPN / 代理 / DNS 变化时应传入新的值并重建 client。
-    #[serde(alias = "networkPathId", skip_serializing_if = "Option::is_none")]
-    pub network_path_id: Option<String>,
 }
 
 fn default_send_timeout() -> u64 {
@@ -275,7 +271,6 @@ impl Default for WsClientConfig {
             race_count: default_race_count(),
             msgpack: false,
             dns: None,
-            network_path_id: None,
         }
     }
 }

--- a/packages/catcher_core/ios/catcher_core.podspec
+++ b/packages/catcher_core/ios/catcher_core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'catcher_core'
-  s.version          = '0.3.12'
+  s.version          = '0.3.13'
   s.summary          = 'Resilient HTTP/WebSocket client backed by Rust core for Flutter.'
   s.description      = <<-DESC
 Resilient HTTP/WebSocket client backed by Rust core for Flutter.

--- a/packages/catcher_core/lib/src/http_client.dart
+++ b/packages/catcher_core/lib/src/http_client.dart
@@ -1106,7 +1106,6 @@ class HttpClientConfig {
   final ProxyAuth? auth;
   final String? bearerToken;
   final bool msgpack;
-  final String? networkPathId;
 
   const HttpClientConfig({
     required this.baseUrl,
@@ -1124,7 +1123,6 @@ class HttpClientConfig {
     this.auth,
     this.bearerToken,
     this.msgpack = false,
-    this.networkPathId,
   });
 
   Map<String, dynamic> toJson() => {
@@ -1143,7 +1141,6 @@ class HttpClientConfig {
         if (auth != null) 'auth': auth!.toJson(),
         if (bearerToken != null) 'bearer_token': bearerToken,
         'msgpack': msgpack,
-        if (networkPathId != null) 'network_path_id': networkPathId,
       };
 }
 

--- a/packages/catcher_core/lib/src/ws_client.dart
+++ b/packages/catcher_core/lib/src/ws_client.dart
@@ -422,7 +422,6 @@ class WsClientConfig {
   final TlsConfig tls;
   final ProxyConfig? proxy;
   final bool msgpack;
-  final String? networkPathId;
 
   const WsClientConfig({
     required this.urls,
@@ -441,7 +440,6 @@ class WsClientConfig {
     this.tls = const TlsConfig(),
     this.proxy,
     this.msgpack = false,
-    this.networkPathId,
   });
 
   Map<String, dynamic> toJson() => {
@@ -462,7 +460,6 @@ class WsClientConfig {
         'tls': tls.toJson(),
         if (proxy != null) 'proxy': proxy!.toJson(),
         'msgpack': msgpack,
-        if (networkPathId != null) 'network_path_id': networkPathId,
       };
 }
 

--- a/packages/catcher_core/macos/catcher_core.podspec
+++ b/packages/catcher_core/macos/catcher_core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'catcher_core'
-  s.version          = '0.3.12'
+  s.version          = '0.3.13'
   s.summary          = 'Resilient HTTP/WebSocket client backed by Rust core for Flutter.'
   s.description      = <<-DESC
 Resilient HTTP/WebSocket client backed by Rust core for Flutter.

--- a/packages/catcher_core/pubspec.yaml
+++ b/packages/catcher_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: catcher_core
-version: 0.3.12
+version: 0.3.13
 description: Resilient HTTP/WebSocket client backed by Rust core for Flutter
 repository: https://github.com/eric8810/catcher
 issue_tracker: https://github.com/eric8810/catcher/issues

--- a/packages/catcher_core/rust/Cargo.lock
+++ b/packages/catcher_core/rust/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "catcher-core"
-version = "0.3.11"
+version = "0.3.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -173,20 +173,21 @@ dependencies = [
 
 [[package]]
 name = "catcher-dns"
-version = "0.3.11"
+version = "0.3.13"
 dependencies = [
  "catcher-core",
  "hickory-proto",
  "hickory-resolver",
  "moka",
  "parking_lot",
+ "reqwest",
  "serde",
  "tokio",
 ]
 
 [[package]]
 name = "catcher-http"
-version = "0.3.11"
+version = "0.3.13"
 dependencies = [
  "async-trait",
  "backon",
@@ -214,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-ws"
-version = "0.3.11"
+version = "0.3.13"
 dependencies = [
  "backon",
  "base64",
@@ -223,6 +224,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "http",
+ "reqwest",
  "rmp-serde",
  "rmpv",
  "serde",
@@ -235,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "catcher_core_ffi"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "catcher-http",
  "catcher-ws",
@@ -1503,7 +1505,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -1513,7 +1514,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2743,6 +2743,7 @@ dependencies = [
  "nom",
  "pin-project",
  "rand 0.8.6",
+ "reqwest",
  "sha1",
  "thiserror",
  "tokio",

--- a/packages/catcher_core/rust/Cargo.toml
+++ b/packages/catcher_core/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher_core_ffi"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2021"
 
 [workspace]


### PR DESCRIPTION
## Summary

对 PR #13（`networkChanged()`）、#14（显式代理）、#15（代理 DNS 行为）做严格架构 review 后发现的一组问题的修复，并发版 0.3.13。主线功能在 master 上工作正常；本 PR 处理残留的小 bug、漏抽象与测试/CI 健康问题。

## 修复的 issue（详见 `docs/issues/028-034`）

| # | 问题 | 修复 |
|---|------|------|
| 28 | `tls_sni_override` 在原生 transport 静默失效 | 改为返回 `InvalidConfig`（reqwest 无法覆写 SNI；纯 TS Node Agent 仍支持） |
| 29 | `network_path_id` 死字段 | 从 Rust + TS + Dart 全部移除（恢复由 `networkChanged()` 承担） |
| 30 | `networkChanged()` 注释言过其实 | 修正注释 + 文档化「在途请求需配合 `cancelAll()`」 |
| 31 | 代理远端 DNS 依赖 reqwest 未文档化行为 | 代码注释 + CI 必跑 `proxy_dns_behavior_test` + arch 文档 |
| 32 | WS 未实现 `pin_sha256` 证书固定 | 记录为 feature gap（非 bug，未改代码） |
| 33 | `q05_subscribe_multiple` 时序 flake + CI 缺 `--no-fail-fast` | 改按生命周期断言 + CI 加 `--no-fail-fast`（此前一个 flake 掩盖整套件） |
| 34 | FFI 回调 UAF（整套并行 SIGSEGV）+ HTTP/SSE destroy 不抑制在途回调 | 测试回调状态 `Box::leak`；HTTP/SSE destroy 加 `cancelled_ids` 与 WS 对齐 |

## 行为变更（vs 0.3.12，升级敏感）

- **DNS 改为按需启用**：不配 `dns` 即用原生解析（此前总是建 Catcher resolver）
- **不再静默回退公共 DNS**：系统 DNS 读取失败时报错，除非 `fallback_to_default_nameservers = true`
- **`socks5://` 自动按 `socks5h://` 处理**（远端解析）
- **`tls_sni_override` 原生路径报错**（此前静默忽略）
- **WS 单连接多 IP 握手故障转移移除**（改由 reqwest 连接层处理）

完整说明见 `CHANGELOG.md` 与 `docs/user-manual/migration.md`「版本升级：0.3.x → 0.3.13」。

## 版本

`chore: release 0.3.13` —— 全部包 0.3.12 → 0.3.13（Cargo.toml/lock、package.json、pubspec、podspec、release-please manifest）。

> 注：本 PR 手动 bump 了版本与 manifest。若仓库走 release-please 自动发版，需改用 `Release-As: 0.3.13` 方式以免与 release PR 冲突。

## 验证

- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo check --workspace` ✅（全部 v0.3.13）
- `catcher-ffi` 全套件 `--no-fail-fast` ✅（codec 4 / http 19 / quality 5 / sse 3）
- `http_test` 并行 5/5 无 SIGSEGV ✅
- `proxy_dns_behavior_test`（http+ws）✅
- `pnpm typecheck` ✅（7 包）
- Dart：机械字段移除，本机无 dart 工具链未跑 `analyze`

🤖 Generated with [Claude Code](https://claude.com/claude-code)