### PR TITLE
fix(napi): enable system-proxy feature in bindings + sync ProxyConfig TS types

### DIFF
--- a/packages/catcher-napi-http/Cargo.toml
+++ b/packages/catcher-napi-http/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 catcher-core = { path = "../catcher-core", version = "0.3.15" }
-catcher-http = { path = "../catcher-http", version = "0.3.15" }
+catcher-http = { path = "../catcher-http", version = "0.3.15", features = ["system-proxy"] }
 napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 serde = { version = "1", features = ["derive"] }

--- a/packages/catcher-napi-http/ts/types.ts
+++ b/packages/catcher-napi-http/ts/types.ts
@@ -117,10 +117,31 @@ export interface ProxyAuth {
   password: string
 }
 
-/** 代理配置 — 对应 Rust ProxyConfig */
-export interface ProxyConfig {
+/**
+ * 代理配置 — 对应 Rust ProxyConfig（判别联合，按 `mode` 区分）。
+ *
+ * - Manual（默认，省略 `mode` 或 `mode: 'manual'`）：必须提供 `url`。
+ * - System（`mode: 'system'`）：自动从 OS 读取系统代理（需构建时启用 `system-proxy`
+ *   feature），`url` 可省略。注意：System 模式仅在调用 `networkChanged()` 后才会
+ *   探测并应用系统代理，首次构建时走直连。
+ */
+export type ProxyConfig = ManualProxyConfig | SystemProxyConfig
+
+/** 手动代理（默认）。`url` 必填。 */
+export interface ManualProxyConfig {
+  mode?: 'manual'
   /** 代理 URL。Catcher 会把 socks5:// 按 socks5h:// 处理，避免代理场景提前本地解析域名。 */
   url: string
+  auth?: ProxyAuth
+  /** 不走代理的 hostname 列表 */
+  no_proxy?: string[]
+}
+
+/** 系统代理：自动从 OS 检测（需构建时启用 `system-proxy` feature）。 */
+export interface SystemProxyConfig {
+  mode: 'system'
+  /** 忽略；系统代理由 `detect_system_proxy()` 在 `networkChanged()` 时解析。 */
+  url?: string
   auth?: ProxyAuth
   /** 不走代理的 hostname 列表 */
   no_proxy?: string[]

--- a/packages/catcher-napi-ws/Cargo.toml
+++ b/packages/catcher-napi-ws/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-catcher-ws = { path = "../catcher-ws", version = "0.3.15", features = ["rustls-tls"] }
+catcher-ws = { path = "../catcher-ws", version = "0.3.15", features = ["rustls-tls", "system-proxy"] }
 napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 serde_json = "1"

--- a/packages/catcher-napi-ws/ts/types.ts
+++ b/packages/catcher-napi-ws/ts/types.ts
@@ -81,10 +81,31 @@ export interface ProxyAuth {
   password: string
 }
 
-/** 代理配置 — 对应 Rust ProxyConfig */
-export interface ProxyConfig {
+/**
+ * 代理配置 — 对应 Rust ProxyConfig（判别联合，按 `mode` 区分）。
+ *
+ * - Manual（默认，省略 `mode` 或 `mode: 'manual'`）：必须提供 `url`。
+ * - System（`mode: 'system'`）：自动从 OS 读取系统代理（需构建时启用 `system-proxy`
+ *   feature），`url` 可省略。注意：System 模式仅在调用 `networkChanged()` 后才会
+ *   探测并应用系统代理，首次构建时走直连。
+ */
+export type ProxyConfig = ManualProxyConfig | SystemProxyConfig
+
+/** 手动代理（默认）。`url` 必填。 */
+export interface ManualProxyConfig {
+  mode?: 'manual'
   /** 代理 URL。Catcher 会把 socks5:// 按 socks5h:// 处理，避免代理场景提前本地解析域名。 */
   url: string
+  auth?: ProxyAuth
+  /** 不走代理的 hostname 列表 */
+  no_proxy?: string[]
+}
+
+/** 系统代理：自动从 OS 检测（需构建时启用 `system-proxy` feature）。 */
+export interface SystemProxyConfig {
+  mode: 'system'
+  /** 忽略；系统代理由 `detect_system_proxy()` 在 `networkChanged()` 时解析。 */
+  url?: string
   auth?: ProxyAuth
   /** 不走代理的 hostname 列表 */
   no_proxy?: string[]


### PR DESCRIPTION
## Problem

0.3.15 shipped `proxy.mode = 'system'` (#18), but the feature is a **no-op in the published npm packages**:

1. **`system-proxy` cargo feature never enabled in the napi bindings.** `catcher-napi-http` depends on `catcher-http` with no features, and `catcher-napi-ws` depends on `catcher-ws` with only `["rustls-tls"]`. Since `catcher-dns`'s default is `["hickory-dns"]` (no `system-proxy`), `detect_system_proxy()` compiles to the `#[cfg(not(feature = "system-proxy"))]` stub that always returns `None`. The release build (`napi build --platform --release`, no `--features`) therefore ships the stub → `proxy.mode = 'system'` silently routes everything direct. CI also only builds default features, so the real `proxy.rs` impl was never compiled/tested.

2. **napi TS types never synced.** The published `dist/types.d.ts` (verified via `npm pack @eric8810/catcher-napi-ws@0.3.15`) still defines `ProxyConfig { url: string; ... }` with required `url` and no `mode` field, so a TS caller cannot write `{ proxy: { mode: 'system' } }` without a compile error.

## Fix

- `catcher-napi-http/Cargo.toml`: `catcher-http` dep → `features = ["system-proxy"]`
- `catcher-napi-ws/Cargo.toml`: `catcher-ws` dep → `features = ["rustls-tls", "system-proxy"]`
- `catcher-napi-{http,ws}/ts/types.ts`: model `ProxyConfig` as a **discriminated union** — `ManualProxyConfig` (default, `url` required) | `SystemProxyConfig` (`mode: 'system'`, `url` optional).

### Why a discriminated union (not just `url?: string`)

The Rust `ProxyConfig` is a flat struct: `#[serde(default)] mode` + `url: Option<String>`. A naive `url?: string` would let `{ mode: 'manual' }` or `{ no_proxy: ['localhost'] }` type-check, then deserialize to `Manual` with `url: None`, and `transport_url()`'s `.expect()` panics during HTTP client construction / the WS connect task. The discriminated union keeps `url` required for the manual/default case, so only `mode: 'system'` may omit it.

## Verification

- `cargo check -p catcher-napi-ws` / `-p catcher-napi-http` now pull in `proxy_cfg v0.4.2` and compile the real `detect_system_proxy()` (previously skipped) — both finish clean.
- `tsc --strict` accepts `{ url: '...' }` and `{ mode: 'system' }`, and **rejects** `{ mode: 'manual' }` / `{ no_proxy: [...] }` (no url).

## Suggested follow-ups (out of scope here)

- **System proxy is only resolved on `networkChanged()`, not at construction.** A fresh `mode: 'system'` client sends initial traffic direct until the host calls `networkChanged()`. Consider resolving in the builder too (the doc comment now notes this caveat).
- **Rust-level `transport_url()` panic still reachable from raw JSON** (`{"proxy":{}}` from a non-TS/FFI caller). The TS union prevents it for TS callers; a Rust-side guard (e.g. validate Manual requires url, or make the build path skip on `url.is_none()` regardless of mode) would close it fully.
- WS reconnect-backoff `skip_backoff` path rebuilds from raw config, skipping System re-detection (inconsistent with the primary network-changed path).
- System re-detection drops user-supplied `auth` (only `no_proxy` is merged).
- CI: add a `--features system-proxy` build/test lane so the real impl is covered.