### PR TITLE
test(ws): clear proxy env vars in host_mapping test

### DIFF
--- a/packages/catcher-ws/src/transport/ws_client.rs
+++ b/packages/catcher-ws/src/transport/ws_client.rs
@@ -1102,6 +1102,26 @@ async fn connection_manager(
 mod tests {
     use super::*;
 
+    /// 清除系统代理环境变量，避免 reqwest 的 auto_sys_proxy（默认开启）把本地
+    /// 连接请求路由到系统代理（如 Clash）。代理会旁路自定义 DNS resolver（见
+    /// ws_client.rs 中 issue #031 说明），导致 host_mapping 里的假域名（如
+    /// `ws.test`）无法解析、握手超时。
+    ///
+    /// 仅用于连接本地测试 server 的场景：本进程所有测试均直连 127.0.0.1，
+    /// 移除代理不影响其正确性；显式代理测试（`ProxyConfig.url`）不读环境变量。
+    fn clear_proxy_env_for_local_tests() {
+        // SAFETY: 仅修改测试进程的环境变量；本模块测试均连接本地地址，
+        // 移除系统代理对所有并行测试无害。
+        unsafe {
+            std::env::remove_var("http_proxy");
+            std::env::remove_var("https_proxy");
+            std::env::remove_var("all_proxy");
+            std::env::remove_var("HTTP_PROXY");
+            std::env::remove_var("HTTPS_PROXY");
+            std::env::remove_var("ALL_PROXY");
+        }
+    }
+
     /// 验证 build_request 成功构建带 headers 和 protocols 的请求
     #[test]
     fn build_request_with_headers_and_protocols() {
@@ -1194,6 +1214,9 @@ mod tests {
     /// 验证显式配置 DNS 时，WS 连接使用 host_mapping。
     #[tokio::test]
     async fn connect_stream_uses_dns_host_mapping() {
+        // 假域名 ws.test 须由 host_mapping 解析为 127.0.0.1；若 reqwest 走了
+        // 系统代理，resolver 会被旁路，请求发往代理导致握手超时。
+        clear_proxy_env_for_local_tests();
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         let server = tokio::spawn(async move {


### PR DESCRIPTION
## 背景

`connect_stream_uses_dns_host_mapping` 测试在本地配置了系统代理（如 Clash，通过 `http_proxy`/`https_proxy`/`all_proxy` 环境变量）的开发机上失败，CI 上不失败。

## 根因

reqwest 的 `auto_sys_proxy` 默认开启，会自动读取系统代理环境变量，把 `ws.test`（RFC 2606 保留的假域名）的请求路由到系统代理（如 Clash）。走代理时 reqwest **不调用自定义 DNS resolver**（issue #031），导致 `host_mapping` 的 `ws.test → 127.0.0.1` 被旁路。代理无法解析假域名 → 请求挂起 → `WsHandshakeTimeout(1000)`。

**为什么 IP 测试不受影响**：`connect_stream_without_dns_config_still_connects_ip` 连 `ws://127.0.0.1`，同样走代理，但代理能把 loopback 请求转回本机，握手成功。

## 修复

在 `connect_stream_uses_dns_host_mapping` 测试开头清除代理环境变量（`http_proxy`/`https_proxy`/`all_proxy` 及大写变体）。

- 仅影响该测试（连本地 server 用假域名）
- 显式代理测试（`ProxyConfig.url`）不读环境变量，不受影响
- CI 环境通常无代理变量，本修复主要解决本地开发环境问题

## 验证

- ✅ 有代理环境变量时测试通过（0.02s）
- ✅ `cargo test -p catcher-ws`：42 单元测试 + 4 集成测试全通过
- ✅ 显式代理测试（`proxy_dns_behavior_test`）3 个全通过，无副作用
- ✅ `cargo clippy -p catcher-ws --all-targets -- -D warnings` 零警告