### PR TITLE
ci(release): add NAPI recovery dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Release
 
 on:
+  workflow_dispatch:
+    inputs:
+      expected_napi_version:
+        description: Expected version for both NAPI packages
+        required: true
+        type: string
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -14,7 +20,9 @@ jobs:
   # 1. npm TS packages (catcher-core/http/ws/web)
   # ──────────────────────────────────────────────
   publish-npm-ts:
-    if: "!startsWith(github.ref, 'refs/tags/catcher_core-v')"
+    if: >-
+      github.event_name != 'workflow_dispatch' &&
+      !startsWith(github.ref, 'refs/tags/catcher_core-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -80,6 +88,21 @@ jobs:
           node-version: 20
           cache: pnpm
           registry-url: https://registry.npmjs.org
+      - name: Validate manual napi-http release
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/master" ]; then
+            echo "::error::Manual NAPI releases must run from master, not $GITHUB_REF"
+            exit 1
+          fi
+          expected="${{ inputs.expected_napi_version }}"
+          actual=$(node -p "require('./packages/catcher-napi-http/package.json').version")
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Expected catcher-napi-http $expected, found $actual"
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.settings.target }}
@@ -151,6 +174,21 @@ jobs:
           node-version: 20
           cache: pnpm
           registry-url: https://registry.npmjs.org
+      - name: Validate manual napi-ws release
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/master" ]; then
+            echo "::error::Manual NAPI releases must run from master, not $GITHUB_REF"
+            exit 1
+          fi
+          expected="${{ inputs.expected_napi_version }}"
+          actual=$(node -p "require('./packages/catcher-napi-ws/package.json').version")
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Expected catcher-napi-ws $expected, found $actual"
+            exit 1
+          fi
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.settings.target }}
@@ -199,6 +237,22 @@ jobs:
           node-version: 20
           cache: pnpm
           registry-url: https://registry.npmjs.org
+      - name: Validate manual NAPI release
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/master" ]; then
+            echo "::error::Manual NAPI releases must run from master, not $GITHUB_REF"
+            exit 1
+          fi
+          expected="${{ inputs.expected_napi_version }}"
+          http_version=$(node -p "require('./packages/catcher-napi-http/package.json').version")
+          ws_version=$(node -p "require('./packages/catcher-napi-ws/package.json').version")
+          if [ "$http_version" != "$expected" ] || [ "$ws_version" != "$expected" ]; then
+            echo "::error::Expected both NAPI packages at $expected; found http=$http_version ws=$ws_version"
+            exit 1
+          fi
       - run: pnpm install
       - name: Download all napi artifacts
         uses: actions/download-artifact@v4
@@ -334,7 +388,9 @@ jobs:
   # 3. Rust crates (crates.io)
   # ──────────────────────────────────────────────
   publish-rust:
-    if: "!startsWith(github.ref, 'refs/tags/catcher_core-v')"
+    if: >-
+      github.event_name != 'workflow_dispatch' &&
+      !startsWith(github.ref, 'refs/tags/catcher_core-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- add a guarded manual dispatch path for NAPI-only releases
- require both NAPI package versions to match the requested version
- require manual releases to run from master
- skip TypeScript npm packages and Rust crates during manual NAPI recovery

## Why

The existing v0.3.17 tag points to a commit before the Direct proxy fix and its NAPI matrix failed, so the two NAPI packages remain at 0.3.16 on npm. Reusing or moving the historical tag would be unsafe. This workflow entry lets us publish the 0.3.17 NAPI packages from current master without attempting to republish already-existing TypeScript or Rust artifacts.

## Validation

- git diff --check
- Ruby YAML parse
- actionlint .github/workflows/release.yml