### PR TITLE
fix(http): recover HTTP 421 requests

### DIFF
--- a/packages/catcher-http/src/transport/http_client.rs
+++ b/packages/catcher-http/src/transport/http_client.rs
@@ -317,8 +317,13 @@ fn build_middleware_client(
 }
 
 impl HttpTransport {
-    /// 发起 HTTP 请求（带熔断器检查 + cancel 支持 + metrics 记录 + 自适应超时 + 并发控制）
+    /// 发起 HTTP 请求（带熔断器检查 + cancel 支持 + metrics 记录 + 自适应超时 + 并发控制）。
+    ///
+    /// HTTP 421 表示当前连接无法为目标源站提供权威响应。收到 421 后仅重建
+    /// 当前传输实例的连接池，并在新连接上重试一次；其他传输实例和飞行中的
+    /// 请求不受影响。
     pub async fn execute(&self, request: HttpRequest) -> Result<HttpResponse, CatcherError> {
+        let retry_request = request.clone();
         let (_, result) = self
             .execute_with_token(
                 0,                                          // dummy request_id, not registered for cancel
@@ -326,7 +331,20 @@ impl HttpTransport {
                 request,
             )
             .await;
-        result
+        if !matches!(&result, Err(CatcherError::HttpError { status: 421, .. })) {
+            return result;
+        }
+
+        // RFC 9110 §15.5.20 permits retrying a 421 response, including a
+        // non-idempotent method, over a different connection. Rebuilding this
+        // transport's client retires its pooled connections without cancelling
+        // unrelated in-flight requests or touching other HttpTransport values.
+        self.network_changed()?;
+        self.metrics.increment_http_retries();
+        let (_, retry_result) = self
+            .execute_with_token(0, tokio_util::sync::CancellationToken::new(), retry_request)
+            .await;
+        retry_result
     }
 
     /// 使用预分配的 token 执行请求（N-03，供 FFI 层使用）。
@@ -895,6 +913,117 @@ fn base64_encode(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn misdirected_post_retries_once_after_connection_pool_reset() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(ResponseTemplate::new(421).set_body_string("misdirected"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/messages"))
+            .respond_with(ResponseTemplate::new(201).set_body_string("accepted"))
+            .mount(&server)
+            .await;
+
+        let transport = HttpTransport::new(HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let response = transport
+            .post(
+                "/messages",
+                br#"{"cmid":"client-message-1"}"#,
+                "application/json",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status, 201);
+        assert_eq!(transport.network_generation.load(Ordering::SeqCst), 1);
+        assert_eq!(transport.metrics().http_retries, 1);
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn persistent_misdirected_response_stops_after_one_retry() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/profile"))
+            .respond_with(ResponseTemplate::new(421).set_body_string("misdirected"))
+            .mount(&server)
+            .await;
+
+        let transport = HttpTransport::new(HttpClientConfig {
+            base_url: server.uri(),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let error = transport.get("/profile").await.unwrap_err();
+
+        assert!(matches!(error, CatcherError::HttpError { status: 421, .. }));
+        assert_eq!(transport.network_generation.load(Ordering::SeqCst), 1);
+        assert_eq!(transport.metrics().http_retries, 1);
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn misdirected_recovery_does_not_cancel_in_flight_request() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/slow"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("slow response")
+                    .set_delay(Duration::from_millis(200)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/profile"))
+            .respond_with(ResponseTemplate::new(421).set_body_string("misdirected"))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/profile"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("profile"))
+            .mount(&server)
+            .await;
+
+        let transport = Arc::new(
+            HttpTransport::new(HttpClientConfig {
+                base_url: server.uri(),
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+        let in_flight_transport = transport.clone();
+        let in_flight = tokio::spawn(async move { in_flight_transport.get("/slow").await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let recovered = transport.get("/profile").await.unwrap();
+        let slow_response = in_flight.await.unwrap().unwrap();
+
+        assert_eq!(recovered.status, 200);
+        assert_eq!(slow_response.status, 200);
+        assert_eq!(slow_response.body, b"slow response");
+    }
 
     #[tokio::test]
     async fn re1_http_error_carries_request_info() {

--- a/packages/catcher-napi-http/README.md
+++ b/packages/catcher-napi-http/README.md
@@ -43,7 +43,7 @@ Pre-built binaries available for Linux (x64/arm64 gnu/musl), macOS (x64/arm64), 
 ## Usage
 
 ```typescript
-import { HttpClient } from '@eric8810/catcher-napi-http'
+import { HttpClient, HttpError } from '@eric8810/catcher-napi-http'
 import type { HttpClientConfig, SseEvent } from '@eric8810/catcher-napi-http/types'
 
 // Config as typed object (recommended) or JSON string
@@ -72,6 +72,14 @@ console.log(resp.status, resp.body.toString())
 await client.post('/messages', Buffer.from(JSON.stringify({ text: 'hello' })), {
   contentType: 'application/json',
 })
+
+try {
+  await client.get('/missing')
+} catch (error) {
+  if (error instanceof HttpError) {
+    console.log(error.status, error.body)
+  }
+}
 
 // Circuit breaker state
 console.log(client.circuitBreakerState()) // 'closed' | 'open' | 'half-open'
@@ -150,6 +158,11 @@ When `msgpack` is enabled, JSON request bodies are encoded as MessagePack and Me
 explicit, environment, and automatic system proxies. `mode: 'system'` detects fixed
 system proxies after `networkChanged()`; PAC/WPAD scripts must be resolved by the host
 application and passed as a manual proxy because Catcher does not embed a PAC engine.
+
+HTTP responses with status `>= 400` reject with `HttpError`, which exposes structured
+`status` and `body` fields. A `421 Misdirected Request` additionally retires this
+client's connection pool and retries once on a fresh connection. Other clients and
+in-flight requests are not cancelled.
 
 ### Methods
 

--- a/packages/catcher-napi-http/ts/client.ts
+++ b/packages/catcher-napi-http/ts/client.ts
@@ -9,6 +9,31 @@ import { loadNativeAddon } from './native'
 
 const { JsHttpClient } = loadNativeAddon('catcher-napi-http')
 
+const NATIVE_HTTP_ERROR_PATTERN = /^HTTP error: status (\d{3}), body: ([\s\S]*)$/
+
+/** Catcher HTTP 状态错误。 */
+export class HttpError extends Error {
+  readonly status: number
+  readonly body: string
+  readonly cause: unknown
+
+  constructor(status: number, body: string, cause?: unknown) {
+    super(`HTTP error: status ${status}, body: ${body}`)
+    this.name = 'HttpError'
+    this.status = status
+    this.body = body
+    this.cause = cause
+  }
+}
+
+function normalizeNativeError(error: unknown): Error {
+  if (error instanceof HttpError) return error
+  const message = error instanceof Error ? error.message : String(error)
+  const match = NATIVE_HTTP_ERROR_PATTERN.exec(message)
+  if (!match) return error instanceof Error ? error : new Error(message)
+  return new HttpError(Number(match[1]), match[2], error)
+}
+
 // ── 选项归一化 ──
 // NAPI-RS 自动把 Rust snake_case 转成 JS camelCase。
 // 旧代码可能仍传 { content_type, timeout_ms }，映射到正确属性名。
@@ -39,33 +64,47 @@ export class HttpClient {
     this._raw = new JsHttpClient(json)
   }
 
+  private async _execute<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+      return await operation()
+    } catch (error) {
+      throw normalizeNativeError(error)
+    }
+  }
+
   async get(url: string, options?: RequestOptions): Promise<HttpResponse> {
-    return this._raw.get(url, normalizeOptions(options))
+    return this._execute(() => this._raw.get(url, normalizeOptions(options)))
   }
 
   async post(url: string, body?: Buffer, options?: RequestOptions): Promise<HttpResponse> {
-    return this._raw.post(url, body ?? undefined, normalizeOptions(options))
+    return this._execute(() =>
+      this._raw.post(url, body ?? undefined, normalizeOptions(options)),
+    )
   }
 
   async put(url: string, body?: Buffer, options?: RequestOptions): Promise<HttpResponse> {
     if (!this._raw.put) {
       throw new Error('put() requires rebuilt native addon (cargo build)')
     }
-    return this._raw.put(url, body ?? undefined, normalizeOptions(options))
+    return this._execute(() =>
+      this._raw.put(url, body ?? undefined, normalizeOptions(options)),
+    )
   }
 
   async delete(url: string, options?: RequestOptions): Promise<HttpResponse> {
     if (!this._raw.delete) {
       throw new Error('delete() requires rebuilt native addon (cargo build)')
     }
-    return this._raw.delete(url, normalizeOptions(options))
+    return this._execute(() => this._raw.delete(url, normalizeOptions(options)))
   }
 
   async patch(url: string, body?: Buffer, options?: RequestOptions): Promise<HttpResponse> {
     if (!this._raw.patch) {
       throw new Error('patch() requires rebuilt native addon (cargo build)')
     }
-    return this._raw.patch(url, body ?? undefined, normalizeOptions(options))
+    return this._execute(() =>
+      this._raw.patch(url, body ?? undefined, normalizeOptions(options)),
+    )
   }
 
   circuitBreakerState(): 'closed' | 'open' | 'half-open' {

--- a/packages/test/integration/napi.test.ts
+++ b/packages/test/integration/napi.test.ts
@@ -2,7 +2,11 @@
  * napi smoke test: verify native addons load and work
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { HttpClient, JsHttpResponse } from '@eric8810/catcher-napi-http'
+import {
+  HttpClient,
+  HttpError,
+  JsHttpResponse,
+} from '@eric8810/catcher-napi-http'
 import { WsClient } from '@eric8810/catcher-napi-ws'
 import { createHttpTestServer, type TestServer } from '../servers/http-server.js'
 import { createWSTestServer, type WSTestServer } from '../servers/ws-server.js'
@@ -38,6 +42,44 @@ describe('@eric8810/catcher-napi-http', () => {
     }))
     const resp: JsHttpResponse = await client.get('/channels')
     expect(resp.status).toBe(200)
+  })
+
+  it('exposes HTTP status and body as a structured HttpError', async () => {
+    const client = new HttpClient({
+      base_url: `http://localhost:${httpServer.port}`,
+      connect_timeout_ms: 5000,
+      response_timeout_ms: 30000,
+    })
+
+    const error = await client.get('/not-found').catch((reason) => reason)
+
+    expect(error).toBeInstanceOf(HttpError)
+    expect(error).toMatchObject({
+      name: 'HttpError',
+      status: 404,
+    })
+    expect(error.body).toContain('not found')
+  })
+
+  it('retries HTTP 421 once after resetting only its connection pool', async () => {
+    const client = new HttpClient({
+      base_url: `http://localhost:${httpServer.port}`,
+      connect_timeout_ms: 5000,
+      response_timeout_ms: 30000,
+    })
+
+    const response = await client.post(
+      '/misdirected-once',
+      Buffer.from('{"cmid":"client-message-1"}'),
+      { contentType: 'application/json' },
+    )
+
+    expect(response.status).toBe(201)
+    expect(JSON.parse(response.body.toString())).toMatchObject({
+      accepted: true,
+      attempts: 2,
+    })
+    expect(client.metrics().httpRetries).toBe(1)
   })
 })
 

--- a/packages/test/servers/http-server.ts
+++ b/packages/test/servers/http-server.ts
@@ -7,6 +7,7 @@
  *   GET  /channels          → channel list
  *   GET  /channels/:id/messages → paginated messages
  *   POST /messages          → send a message
+ *   POST /misdirected-once  → first request returns 421, fresh retry returns 201
  *
  * All endpoints accept a ?delay=ms query param to simulate server processing time.
  */
@@ -22,6 +23,7 @@ export interface TestServer {
 export function createHttpTestServer(): Promise<TestServer> {
   return new Promise((resolve) => {
     const connections = new Set<import('net').Socket>()
+    let misdirectedRequests = 0
     const server = http.createServer((req, res) => {
       const url = new URL(req.url ?? '/', `http://${req.headers.host}`)
       const delay = parseInt(url.searchParams.get('delay') ?? '0', 10)
@@ -70,6 +72,17 @@ export function createHttpTestServer(): Promise<TestServer> {
             }
           })
           return // prevent double respond
+        } else if (url.pathname === '/misdirected-once' && req.method === 'POST') {
+          req.resume()
+          req.on('end', () => {
+            misdirectedRequests++
+            if (misdirectedRequests === 1) {
+              respond(421, { error: 'misdirected' })
+            } else {
+              respond(201, { accepted: true, attempts: misdirectedRequests })
+            }
+          })
+          return
         } else if (url.pathname === '/upload' && req.method === 'POST') {
           // Simulate 2MB upload
           let received = 0


### PR DESCRIPTION
## Problem

A pooled connection can become stale or be coalesced to the wrong origin after proxy or network changes. In the observed Moti + Clash Verge incident, Fastly returned HTTP 421 with a TLS SAN mismatch message. Catcher classified every 4xx as non-retryable, and the NAPI wrapper exposed only a generic Error message, so the application could neither recover locally nor reliably inspect error.status.

## Changes

- Detect HTTP 421 after the normal request pipeline returns.
- Retire only the current HttpTransport connection pool and retry once on a fresh connection.
- Keep other clients and already in-flight requests untouched.
- Stop after the bounded retry and surface a persistent 421.
- Export HttpError from the NAPI TypeScript wrapper with structured status, body, and cause fields.
- Document the behavior and add Rust plus NAPI regression coverage.

RFC 9110 section 15.5.20 explicitly permits retrying a 421 request over a different connection, even when the method is not idempotent.

## Validation

- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- pnpm build:ts
- pnpm typecheck
- focused NAPI suite: 7 passed
- focused weak-network retry rerun: passed
- git diff --check
- modified Rust file rustfmt check: passed

The full pnpm test run completed 345 passed and 1 skipped, with two unrelated harness failures: the randomized packet-loss assertion (passed when rerun alone) and the optional-agent real-proxy CONNECT test. The latter test server handles regular proxy requests but not CONNECT, and this change does not touch the TypeScript proxy implementation.