### PR TITLE
release: v0.3.18 HTTP 421 recovery

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,15 +1,15 @@
 {
-  "packages/catcher-core-ts": "0.3.17",
-  "packages/catcher-http-ts": "0.3.17",
-  "packages/catcher-ws-ts": "0.3.17",
-  "packages/catcher-web": "0.3.17",
-  "packages/catcher-napi-http": "0.3.17",
-  "packages/catcher-napi-ws": "0.3.17",
-  "packages/catcher-core": "0.3.17",
-  "packages/catcher-dns": "0.3.17",
-  "packages/catcher-http": "0.3.17",
-  "packages/catcher-ws": "0.3.17",
-  "packages/catcher-ffi": "0.3.17",
-  "packages/catcher-uniffi": "0.3.17",
-  "packages/catcher_core": "0.3.17"
+  "packages/catcher-core-ts": "0.3.18",
+  "packages/catcher-http-ts": "0.3.18",
+  "packages/catcher-ws-ts": "0.3.18",
+  "packages/catcher-web": "0.3.18",
+  "packages/catcher-napi-http": "0.3.18",
+  "packages/catcher-napi-ws": "0.3.18",
+  "packages/catcher-core": "0.3.18",
+  "packages/catcher-dns": "0.3.18",
+  "packages/catcher-http": "0.3.18",
+  "packages/catcher-ws": "0.3.18",
+  "packages/catcher-ffi": "0.3.18",
+  "packages/catcher-uniffi": "0.3.18",
+  "packages/catcher_core": "0.3.18"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [release-please](https://github.com/googleapis/release-please) for automated management.
 
+## 0.3.18 (2026-08-07)
+
+> 修复代理/VPN/网络路径变化后服务端返回 HTTP 421（Misdirected Request）时客户端持续失败的问题，并为 NAPI 调用方提供结构化 HTTP 状态错误。
+
+### 🐛 Bug Fixes
+
+- **HTTP 421 自动恢复**：`catcher-http` 收到 421 后仅重建当前 transport 的连接池，并在新连接上重试一次；持续返回 421 时停止重试，避免无限循环。
+- **保留在途请求**：421 恢复不会取消同一 transport 上其他正在执行的请求，也不会影响其他 `HttpTransport` 实例。
+- **NAPI 结构化状态错误**：`@eric8810/catcher-napi-http` 将原生 HTTP 状态错误规范化为导出的 `HttpError`，上层可直接读取 `status`、`body` 和 `cause`。
+- **跨层回归覆盖**：新增 Rust 与 NAPI 集成测试，覆盖 POST 421 后成功恢复、持续 421 只重试一次、在途请求不被取消，以及结构化状态字段。
+
+### 📦 Packaging
+
+- 所有 npm、Rust、NAPI 和 Flutter 包统一同步到 `0.3.18`。
+
 ## 0.3.17 (2026-06-15)
 
 > 修复 Flutter WebSocket 直连可用性：默认简单直连场景改走 yawc native backend，高级网络配置继续走 reqwest backend；同时完善网络切换重连、Apple framework 元数据与 Flutter 兼容性处理。

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ npm install @eric8810/catcher-web
 
 ```yaml
 dependencies:
-  catcher_core: ^0.3.17
+  catcher_core: ^0.3.18
 ```
 
 ### Usage

--- a/docs/releases/0.3.18.md
+++ b/docs/releases/0.3.18.md
@@ -1,0 +1,49 @@
+# Catcher 0.3.18
+
+Release date: 2026-08-07
+
+## Summary
+
+Catcher 0.3.18 fixes a persistent HTTP failure that can occur after a proxy, VPN,
+or network-path change. When the server responds with `421 Misdirected Request`,
+the native HTTP transport now retires its pooled connections and retries the
+request once on a fresh connection.
+
+## HTTP 421 recovery
+
+- Recovery is scoped to the `HttpTransport` instance that received the 421.
+- The original request, including POST requests, is retried exactly once.
+- A second 421 is returned to the caller; there is no retry loop.
+- Other requests already in flight are not cancelled.
+- The recovery increments the existing HTTP retry metric.
+
+## Structured NAPI HTTP errors
+
+`@eric8810/catcher-napi-http` now exports `HttpError`. HTTP status failures expose
+`status`, `body`, and `cause`, allowing Electron and Node.js callers to handle
+specific status codes without parsing an opaque error string.
+
+```ts
+import { HttpError } from '@eric8810/catcher-napi-http'
+
+try {
+  await client.get('/profile')
+} catch (error) {
+  if (error instanceof HttpError && error.status === 421) {
+    // The native client already attempted one fresh-connection recovery.
+  }
+}
+```
+
+## Validation
+
+- Rust workspace check, clippy with warnings denied, and full tests
+- TypeScript build, typecheck, and unit tests
+- Dart FFI roundtrip tests
+- NAPI integration coverage for recovery and structured status errors
+
+## Upgrade
+
+All Catcher packages are version-aligned at `0.3.18`. Applications using the
+native Node.js transport should upgrade `@eric8810/catcher-napi-http` and install
+the matching platform package selected through its optional dependencies.

--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-core"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-dns"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "catcher-core",
  "hickory-proto",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-ffi"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "catcher-core",
  "catcher-http",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-http"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "async-trait",
  "backon",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-napi-http"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "base64",
  "bytes",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-napi-ws"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "catcher-ws",
  "napi",
@@ -425,14 +425,14 @@ dependencies = [
 
 [[package]]
 name = "catcher-test-support"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "catcher-uniffi"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "catcher-core",
  "catcher-http",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-ws"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "backon",
  "base64",

--- a/packages/catcher-core-ts/package.json
+++ b/packages/catcher-core-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-core",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Catcher shared type definitions — zero runtime dependencies",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-core/Cargo.toml
+++ b/packages/catcher-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-core"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "Shared core types and errors for catcher — zero I/O dependencies"
 license = "MIT"

--- a/packages/catcher-core/README.md
+++ b/packages/catcher-core/README.md
@@ -24,7 +24,7 @@ Shared core types and errors for the [catcher](https://github.com/eric8810/catch
 
 ```toml
 [dependencies]
-catcher-core = "0.3.17"
+catcher-core = "0.3.18"
 ```
 
 ```rust

--- a/packages/catcher-dns/Cargo.toml
+++ b/packages/catcher-dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-dns"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "Shared DNS resolver and system proxy detection for catcher"
 license = "MIT"
@@ -13,7 +13,7 @@ reqwest-resolver = ["dep:reqwest"]
 system-proxy = ["dep:proxy_cfg"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.17" }
+catcher-core = { path = "../catcher-core", version = "0.3.18" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["net", "rt", "time", "macros"] }
 parking_lot = "0.12"

--- a/packages/catcher-dns/README.md
+++ b/packages/catcher-dns/README.md
@@ -19,7 +19,7 @@ Shared DNS resolver for the [catcher](https://github.com/eric8810/catcher) toolk
 
 ```toml
 [dependencies]
-catcher-dns = "0.3.17"
+catcher-dns = "0.3.18"
 ```
 
 ```rust

--- a/packages/catcher-ffi/Cargo.toml
+++ b/packages/catcher-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-ffi"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "Unified C ABI library for catcher — links HTTP + WS + codec into a single .so/.dylib"
 license = "MIT"
@@ -11,15 +11,15 @@ crate-type = ["cdylib", "lib"]
 name = "catcher_ffi"
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.17" }
-catcher-http = { path = "../catcher-http", version = "0.3.17" }
-catcher-ws = { path = "../catcher-ws", version = "0.3.17" }
+catcher-core = { path = "../catcher-core", version = "0.3.18" }
+catcher-http = { path = "../catcher-http", version = "0.3.18" }
+catcher-ws = { path = "../catcher-ws", version = "0.3.18" }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.17" }
-catcher-http = { path = "../catcher-http", version = "0.3.17" }
-catcher-ws = { path = "../catcher-ws", version = "0.3.17" }
+catcher-core = { path = "../catcher-core", version = "0.3.18" }
+catcher-http = { path = "../catcher-http", version = "0.3.18" }
+catcher-ws = { path = "../catcher-ws", version = "0.3.18" }
 wiremock = "0.6"
 tokio-test = "0.4"

--- a/packages/catcher-http-ts/package.json
+++ b/packages/catcher-http-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-http",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Catcher HTTP client — resilient transport with retry, circuit breaker, priority scheduling",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-http/Cargo.toml
+++ b/packages/catcher-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-http"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "HTTP client for catcher — resilient transport with retry, circuit breaker, priority scheduling"
 license = "MIT"
@@ -15,8 +15,8 @@ napi = ["dep:napi", "dep:napi-derive"]
 system-proxy = ["catcher-dns/system-proxy"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.17" }
-catcher-dns = { path = "../catcher-dns", version = "0.3.17", default-features = false }
+catcher-core = { path = "../catcher-core", version = "0.3.18" }
+catcher-dns = { path = "../catcher-dns", version = "0.3.18", default-features = false }
 
 # ── 异步运行时 ──
 tokio = { version = "1", features = ["sync", "time", "net", "io-util", "macros"] }

--- a/packages/catcher-http/README.md
+++ b/packages/catcher-http/README.md
@@ -24,7 +24,7 @@ Resilient HTTP client for the [catcher](https://github.com/eric8810/catcher) too
 
 ```toml
 [dependencies]
-catcher-http = { version = "0.3.17", default-features = true }
+catcher-http = { version = "0.3.18", default-features = true }
 ```
 
 ### Basic HTTP request

--- a/packages/catcher-napi-http/Cargo.toml
+++ b/packages/catcher-napi-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-napi-http"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "catcher HTTP napi-rs Node.js native bindings"
 license = "MIT"
@@ -9,8 +9,8 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.17" }
-catcher-http = { path = "../catcher-http", version = "0.3.17", features = ["system-proxy"] }
+catcher-core = { path = "../catcher-core", version = "0.3.18" }
+catcher-http = { path = "../catcher-http", version = "0.3.18", features = ["system-proxy"] }
 napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 serde = { version = "1", features = ["derive"] }

--- a/packages/catcher-napi-http/package.json
+++ b/packages/catcher-napi-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-napi-http",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "catcher HTTP native addon for Node.js via napi-rs",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/packages/catcher-napi-ws/Cargo.toml
+++ b/packages/catcher-napi-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-napi-ws"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "catcher WebSocket napi-rs Node.js native bindings"
 license = "MIT"
@@ -9,7 +9,7 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-catcher-ws = { path = "../catcher-ws", version = "0.3.17", features = ["rustls-tls", "system-proxy"] }
+catcher-ws = { path = "../catcher-ws", version = "0.3.18", features = ["rustls-tls", "system-proxy"] }
 napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt", "serde-json"] }
 napi-derive = "2"
 serde_json = "1"

--- a/packages/catcher-napi-ws/package.json
+++ b/packages/catcher-napi-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-napi-ws",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "catcher WebSocket native addon for Node.js via napi-rs",
   "main": "dist/client.js",
   "types": "dist/client.d.ts",

--- a/packages/catcher-test-support/Cargo.toml
+++ b/packages/catcher-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-test-support"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 publish = false
 

--- a/packages/catcher-uniffi/Cargo.toml
+++ b/packages/catcher-uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-uniffi"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "UniFFI bindings for catcher — auto-generates Swift + Kotlin from Rust API"
 license = "MIT"
@@ -11,9 +11,9 @@ crate-type = ["cdylib", "staticlib"]
 name = "catcher_uniffi"
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.17" }
-catcher-http = { path = "../catcher-http", version = "0.3.17" }
-catcher-ws = { path = "../catcher-ws", version = "0.3.17" }
+catcher-core = { path = "../catcher-core", version = "0.3.18" }
+catcher-http = { path = "../catcher-http", version = "0.3.18" }
+catcher-ws = { path = "../catcher-ws", version = "0.3.18" }
 uniffi = { version = "0.28", features = ["cli"] }
 serde_json = "1"
 thiserror = "1"

--- a/packages/catcher-web/package.json
+++ b/packages/catcher-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-web",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Catcher HTTP client for browsers — fetch-based with retry, circuit breaker & priority queue",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-ws-ts/package.json
+++ b/packages/catcher-ws-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eric8810/catcher-ws",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Catcher WebSocket client — resilient reconnect, multi-endpoint racing, msgpack codec",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/catcher-ws/Cargo.toml
+++ b/packages/catcher-ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher-ws"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 description = "WebSocket client for catcher — resilient reconnect, heartbeat, multi-endpoint racing"
 license = "MIT"
@@ -12,8 +12,8 @@ rustls-tls = ["yawc/rustls-ring", "reqwest/rustls"]
 system-proxy = ["catcher-dns/system-proxy"]
 
 [dependencies]
-catcher-core = { path = "../catcher-core", version = "0.3.17" }
-catcher-dns = { path = "../catcher-dns", version = "0.3.17", features = ["reqwest-resolver"] }
+catcher-core = { path = "../catcher-core", version = "0.3.18" }
+catcher-dns = { path = "../catcher-dns", version = "0.3.18", features = ["reqwest-resolver"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "net", "io-util", "macros"] }
 futures-util = "0.3"
 backon = "1"

--- a/packages/catcher-ws/README.md
+++ b/packages/catcher-ws/README.md
@@ -28,7 +28,7 @@ Resilient WebSocket client for the [catcher](https://github.com/eric8810/catcher
 
 ```toml
 [dependencies]
-catcher-ws = "0.3.17"
+catcher-ws = "0.3.18"
 ```
 
 ### Basic WebSocket connection

--- a/packages/catcher_core/CHANGELOG.md
+++ b/packages/catcher_core/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.3.18
+
+### Bug Fixes
+
+- **HTTP 421 recovery**: native HTTP requests rebuild the current transport's connection pool and retry once after a `421 Misdirected Request`, without cancelling unrelated in-flight requests.
+- **Structured NAPI HTTP errors**: the Node.js NAPI wrapper exports `HttpError` with `status`, `body`, and `cause` fields so host applications can inspect HTTP status failures directly.
+
+### Packaging
+
+- Synchronize all Catcher package versions to `0.3.18`; the Flutter API surface is otherwise unchanged.
+
 ## 0.3.17
 
 ### Bug Fixes

--- a/packages/catcher_core/README.md
+++ b/packages/catcher_core/README.md
@@ -20,7 +20,7 @@ Resilient HTTP/WebSocket client for **Flutter** — powered by a **Rust core** v
 
 ```yaml
 dependencies:
-  catcher_core: ^0.3.17
+  catcher_core: ^0.3.18
 ```
 
 > **Note:** The pub.dev package includes the native Rust libraries for supported platforms. If you build from a source checkout or need custom targets, see the [Flutter manual build guide](../../docs/user-manual/flutter.md#手动构建-android--ios-native-二进制).

--- a/packages/catcher_core/ios/catcher_core.podspec
+++ b/packages/catcher_core/ios/catcher_core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'catcher_core'
-  s.version          = '0.3.17'
+  s.version          = '0.3.18'
   s.summary          = 'Resilient HTTP/WebSocket client backed by Rust core for Flutter.'
   s.description      = <<-DESC
 Resilient HTTP/WebSocket client backed by Rust core for Flutter.

--- a/packages/catcher_core/macos/catcher_core.podspec
+++ b/packages/catcher_core/macos/catcher_core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'catcher_core'
-  s.version          = '0.3.17'
+  s.version          = '0.3.18'
   s.summary          = 'Resilient HTTP/WebSocket client backed by Rust core for Flutter.'
   s.description      = <<-DESC
 Resilient HTTP/WebSocket client backed by Rust core for Flutter.

--- a/packages/catcher_core/pubspec.yaml
+++ b/packages/catcher_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: catcher_core
-version: 0.3.17
+version: 0.3.18
 description: Resilient HTTP/WebSocket client backed by Rust core for Flutter
 repository: https://github.com/eric8810/catcher
 issue_tracker: https://github.com/eric8810/catcher/issues

--- a/packages/catcher_core/rust/Cargo.lock
+++ b/packages/catcher_core/rust/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "catcher-core"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-dns"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "catcher-core",
  "hickory-proto",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-http"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "async-trait",
  "backon",
@@ -215,7 +215,7 @@ dependencies = [
 
 [[package]]
 name = "catcher-ws"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "backon",
  "base64",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "catcher_core_ffi"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "catcher-http",
  "catcher-ws",

--- a/packages/catcher_core/rust/Cargo.toml
+++ b/packages/catcher_core/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "catcher_core_ffi"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2021"
 
 [workspace]


### PR DESCRIPTION
## Summary
- align every Catcher package and internal dependency at 0.3.18
- document HTTP 421 fresh-connection recovery and structured NAPI HttpError
- update Cargo lockfiles, Flutter metadata, package examples, and release notes

## Validation
- cargo metadata --locked for both Rust workspaces
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --no-fail-fast
- pnpm build:ts
- pnpm typecheck
- pnpm test:napi: 30 passed, including structured status and 421 recovery
- default pnpm test: 346 passed, 1 skipped; local Node 22 P8 proxy forwarding test failed because the local proxy closed before CONNECT response, so merge remains gated on GitHub CI

## Release
After merge, tag the exact merge commit with v0.3.18, verify npm/crates publication, then tag the same commit with catcher_core-v0.3.18 for pub.dev.