### PR TITLE
docs(flutter): add 0.3.19 changelog

### DIFF
--- a/packages/catcher_core/CHANGELOG.md
+++ b/packages/catcher_core/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.3.19
+
+### Bug Fixes
+
+- Preserve structured transport failure details through NAPI HTTP retries, including error codes and chained causes, so host applications can diagnose connection failures after retries are exhausted.
+
+### Packaging
+
+- Synchronize the Flutter package version with the unified Catcher `0.3.19` release; the Dart API surface is otherwise unchanged.
+
 ## 0.3.18
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- add the missing `catcher_core` 0.3.19 package changelog entry
- unblock `dart pub publish --dry-run`, which rejects a package whose changelog does not mention its current version

## Release context

The `catcher_core-v0.3.19` release built and verified all five native platform bundles, but stopped before pub.dev upload with exit code 65 because this package-local changelog still ended at 0.3.18.

## Validation

- `git diff --check`
- exact fix targets the failed package validation message from Release run 31676591050